### PR TITLE
i #107 Bugfix download_mod_mbox missing leading zeros

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -126,7 +126,7 @@ download_mod_mbox <- function(base_url, mailinglist, from, to) {
       counter <- counter + 1
 
       #Generate file destinations
-      destination[[counter]] <- sprintf("%d%d.mbox", year, month)
+      destination[[counter]] <- sprintf("%d%02d.mbox", year, month)
 
       #Try file download and save result
       x <- httr::GET(paste(base_url, mailinglist, destination[[counter]], sep = "/"), httr::write_disk(destination[[counter]], overwrite=TRUE))


### PR DESCRIPTION
Created a pull request for issue #107. Fixed a bug that caused download_mod_mbox to incorrectly download the .mbox files for January to September. The bug was caused due to missing leading zeros for months 1-9, should have been 01-09.