### PR TITLE
i #216 Add tags for GitHub Issues and PRs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ __kaiaulu 0.0.0.9700 (in development)__
 
 ### MINOR IMPROVEMENTS
 
+ * Adds tags column to `github_parse_project_issue()`, `github_parse_project_pull_request()` so bug count can also be computed from GitHub API. [#216](https://github.com/sailuh/kaiaulu/issues/216)
  * A progress bar has been added to `parse_dv8_architectural_flaws()`. Each tick tracks one folder of flaws (progressBar auto resets the tick to 0 on loop completion, so instance progress bar requires further function refactoring and is deferred for now). [#209](https://github.com/sailuh/kaiaulu/issues/209)
  * graph_to_dsmj is now vectorized, increasing performance [#209](https://github.com/sailuh/kaiaulu/issues/209)
  * Bugzilla API now allows for output file to be specified. [#202](https://github.com/sailuh/kaiaulu/issues/202)

--- a/R/github.R
+++ b/R/github.R
@@ -110,6 +110,13 @@ github_parse_project_issue <- function(api_responses){
     parsed_response[["title"]] <- api_response[["title"]]
     parsed_response[["body"]] <- api_response[["body"]]
 
+    parsed_response[["labels"]] <- api_response[["labels"]]
+    if(length(parsed_response[["labels"]]) > 0){
+      parsed_response[["labels"]] <- stringi::stri_c(sapply(parsed_response[["labels"]],"[[","name"),collapse = ",")
+    }else{
+      parsed_response[["labels"]] <- NA_character_
+    }
+
     parsed_response <- as.data.table(parsed_response)
 
     return(parsed_response)
@@ -156,6 +163,13 @@ github_parse_project_pull_request <- function(api_responses){
     parsed_response[["author_association"]] <- api_response[["author_association"]]
     parsed_response[["title"]] <- api_response[["title"]]
     parsed_response[["body"]] <- api_response[["body"]]
+
+    parsed_response[["labels"]] <- api_response[["labels"]]
+    if(length(parsed_response[["labels"]]) > 0){
+      parsed_response[["labels"]] <- stringi::stri_c(sapply(parsed_response[["labels"]],"[[","name"),collapse = ",")
+    }else{
+      parsed_response[["labels"]] <- NA_character_
+    }
 
     parsed_response <- as.data.table(parsed_response)
 

--- a/conf/kaiaulu.yml
+++ b/conf/kaiaulu.yml
@@ -65,7 +65,7 @@ issue_tracker:
     owner: sailuh
     repo: kaiaulu
     # Download using `download_github_comments.Rmd`
-    replies: ../../rawdata/github/kaiaulu/
+    replies: ../../rawdata/github/kaiaulu
 
 #vulnerabilities:
   # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)

--- a/vignettes/download_github_comments.Rmd
+++ b/vignettes/download_github_comments.Rmd
@@ -23,6 +23,8 @@ require(kaiaulu)
 require(data.table)
 require(jsonlite)
 require(knitr)
+require(magrittr)
+require(gt)
 ```
 
 
@@ -42,7 +44,7 @@ Therefore, in this Notebook we have to rely on three endpoints from the GitHub A
 To use the pipeline, you must specify the organization and project of interest, and your token. Obtain a github token following the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 
 ```{r}
-conf <- yaml::read_yaml("../conf/helix.yml")
+conf <- yaml::read_yaml("../conf/kaiaulu.yml")
 save_path <- path.expand(conf[["issue_tracker"]][["github"]][["replies"]]) # Path you wish to save all raw data. A folder with the repo name and sub-folders will be created.
 owner <- conf[["issue_tracker"]][["github"]][["owner"]] # Has to match github organization (e.g. github.com/sailuh)
 repo <- conf[["issue_tracker"]][["github"]][["repo"]] # Has to match github repository (e.g. github.com/sailuh/perceive)
@@ -135,6 +137,8 @@ Note the parsed data will include the **body** column, but it is not shown in th
 
 ## Issues 
 
+The issue endpoint provides issue-related metadata such as labels. This can be helpful for the analysis of bug counts, if the project uses bug labels.
+
 ```{r}
 all_issue <- lapply(list.files(save_path_issue,
                                      full.names = TRUE),read_json)
@@ -142,12 +146,13 @@ all_issue <- lapply(all_issue,
                                    github_parse_project_issue)
 all_issue <- rbindlist(all_issue,fill=TRUE)
 
-all_issue_display <- all_issue
-all_issue_display[,body:=NULL]
-kable(head(all_issue_display))
+head(all_issue)  %>%
+  gt(auto_align = FALSE) 
 ```
 
 ## Pull Requests
+
+Similarly to the Issue API, we can also obtain other metadata from pull requests, including their labels.
 
 ```{r}
 all_pr <- lapply(list.files(save_path_pull_request,
@@ -156,9 +161,8 @@ all_pr <- lapply(all_pr,
                                    github_parse_project_pull_request)
 all_pr <- rbindlist(all_pr,fill=TRUE)
 
-all_pr_display <- all_pr 
-all_pr_display[,body:=NULL]
-kable(head(all_pr_display))
+tail(all_pr,1)  %>%
+  gt(auto_align = FALSE) 
 ```
 
 ## Issue or PR Comments
@@ -170,9 +174,8 @@ all_issue_or_pr_comments <- lapply(all_issue_or_pr_comments,
                                    github_parse_project_issue_or_pr_comments)
 all_issue_or_pr_comments <- rbindlist(all_issue_or_pr_comments,fill=TRUE)
 
-all_issue_or_pr_comments_display <- all_issue_or_pr_comments
-all_issue_or_pr_comments_display[,body:=NULL]
-kable(head(all_issue_or_pr_comments_display))
+head(all_issue_or_pr_comments,2)  %>%
+  gt(auto_align = FALSE) 
 ```
 
 
@@ -188,9 +191,9 @@ Below we show the result of such merge, including the name and e-mail fields obt
 
 ```{r}
 replies <- parse_github_replies(save_path)
-replies_display <- replies
-replies_display[,reply_body:=NULL]
-kable(head(replies_display,10))
+
+tail(replies,2)  %>%
+  gt(auto_align = FALSE) 
 ```
 
 


### PR DESCRIPTION
The parsers:

 * github_parse_project_issue()
 * github_parse_project_pull_request()

Now also include a column "labels", which includes the tags separated by "," if present on issue or PRs.