### PR TITLE
323 pulling request comment via GitHub rest api

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -44,7 +44,7 @@ parse_config <- function(config_path) {
 #' @export
 create_file_directory <- function(conf, verbose = TRUE) {
   # Create the git_repo folder
-  create_file_path(conf$version_control$log)
+  create_file_path(conf$version_control$log, verbose)
 
   # Create the mailing_list directory, if needed
   if (!is.null(conf$mailing_list)) {
@@ -54,7 +54,7 @@ create_file_directory <- function(conf, verbose = TRUE) {
       project_keys <- names(conf$mailing_list$mod_mbox)
       for (key in project_keys) {
         mailing_list <- conf$mailing_list$mod_mbox[[key]]
-        create_file_path(mailing_list$save_folder_path)
+        create_file_path(mailing_list$save_folder_path, verbose)
       }
     } else {
       if (verbose) {
@@ -67,7 +67,7 @@ create_file_directory <- function(conf, verbose = TRUE) {
       project_keys <- names(conf$mailing_list$pipermail)
       for (key in project_keys) {
         mailing_list <- conf$mailing_list$pipermail[[key]]
-        create_file_path(mailing_list$save_folder_path)
+        create_file_path(mailing_list$save_folder_path, verbose)
       }
     } else {
       if (verbose) {
@@ -88,8 +88,8 @@ create_file_directory <- function(conf, verbose = TRUE) {
       project_keys <- names(conf$issue_tracker$jira)
       for (key in project_keys) {
         issue_tracker <- conf$issue_tracker$jira[[key]]
-        create_file_path(issue_tracker$issues)
-        create_file_path(issue_tracker$issue_comments)
+        create_file_path(issue_tracker$issues, verbose)
+        create_file_path(issue_tracker$issue_comments, verbose)
       }
     } else {
       if (verbose) {
@@ -102,13 +102,14 @@ create_file_directory <- function(conf, verbose = TRUE) {
       project_keys <- names(conf$issue_tracker$github)
       for (key in project_keys) {
         issue_tracker <- conf$issue_tracker$github[[key]]
-        create_file_path(issue_tracker$issue_or_pr_comment)
-        create_file_path(issue_tracker$issue)
-        create_file_path(issue_tracker$issue_search)
-        create_file_path(issue_tracker$issue_event)
-        create_file_path(issue_tracker$pull_request)
-        create_file_path(issue_tracker$commit)
-        create_file_path(issue_tracker$discussion)
+        create_file_path(issue_tracker$issue_or_pr_comment, verbose)
+        create_file_path(issue_tracker$issue, verbose)
+        create_file_path(issue_tracker$issue_search, verbose)
+        create_file_path(issue_tracker$issue_event, verbose)
+        create_file_path(issue_tracker$pull_request, verbose)
+        create_file_path(issue_tracker$pr_comment, verbose)
+        create_file_path(issue_tracker$commit, verbose)
+        create_file_path(issue_tracker$discussion, verbose)
       }
     } else {
       if (verbose) {
@@ -121,8 +122,8 @@ create_file_directory <- function(conf, verbose = TRUE) {
       project_keys <- names(conf$issue_tracker$bugzilla)
       for (key in project_keys) {
         issue_tracker <- conf$issue_tracker$bugzilla[[key]]
-        create_file_path(issue_tracker$issues)
-        create_file_path(issue_tracker$issue_comments)
+        create_file_path(issue_tracker$issues, verbose)
+        create_file_path(issue_tracker$issue_comments, verbose)
       }
     } else {
       if (verbose) {
@@ -139,7 +140,7 @@ create_file_directory <- function(conf, verbose = TRUE) {
   if (!is.null(conf$tool)) {
     # Check for dv8
     if (!is.null(conf$tool$dv8)) {
-      create_file_path(conf$tool$dv8$folder_path)
+      create_file_path(conf$tool$dv8$folder_path, verbose)
     } else {
       if (verbose) {
         message("dv8 is unused")
@@ -147,7 +148,7 @@ create_file_directory <- function(conf, verbose = TRUE) {
     }
     # Check for srcml
     if (!is.null(conf$tool$srcml)) {
-      create_file_path(conf$tool$srcml$srcml_path)
+      create_file_path(conf$tool$srcml$srcml_path, verbose)
     } else {
       if (verbose) {
         message("srcml is unused")
@@ -155,8 +156,8 @@ create_file_directory <- function(conf, verbose = TRUE) {
     }
     # Check for pattern4
     if (!is.null(conf$tool$pattern4)) {
-      create_file_path(conf$tool$pattern4$class_folder_path)
-      create_file_path(conf$tool$pattern4$output_filepath)
+      create_file_path(conf$tool$pattern4$class_folder_path, verbose)
+      create_file_path(conf$tool$pattern4$output_filepath, verbose)
     } else {
       if (verbose) {
         message("pattern4 is unused")
@@ -164,8 +165,8 @@ create_file_directory <- function(conf, verbose = TRUE) {
     }
     # Check for understand
     if (!is.null(conf$tool$understand)) {
-      create_file_path(conf$tool$understand$project_path)
-      create_file_path(conf$tool$understand$output_path)
+      create_file_path(conf$tool$understand$project_path, verbose)
+      create_file_path(conf$tool$understand$output_path, verbose)
     }
   } else {
     if (verbose) {
@@ -702,6 +703,31 @@ get_github_pull_request_path <- function(config_file, project_key_index) {
   }
 
   return(pull_request_path)
+}
+
+#' Returns the local folder path for GitHub Pull Request Review Comments for a specific
+#' project key.
+#'
+#' @description This function returns the local folder path for GitHub Pull
+#' Request Comments for a specific project key, that is specified in the input
+#' parameter `config_file`. The input, `config_file` must be a parsed
+#' configuration file. The function will inform the user if the local folder
+#' path for the pull request comments exists in the parsed configuration file,
+#' `config_file`.
+#'
+#' @param config_file The parsed configuration file obtained from \code{\link{parse_config}}.
+#' @param project_key_index The name of the index of the project key (e.g. "project_key_1" or "project_key_2").
+#' @return The local folder path for GitHub pull request review comments for project specified by key `project_key_index`.
+#' @export
+get_github_pr_comments_path <- function(config_file, project_key_index) {
+
+  pr_comments_path <- config_file[["issue_tracker"]][["github"]][[project_key_index]][["pr_comments"]]
+
+  if (is.null(pr_comments_path)) {
+    warning("Attribute does not exist in the configuration file.")
+  }
+
+  return(pr_comments_path)
 }
 
 #' Returns the local folder path for GitHub issue events for a specific project

--- a/R/config.R
+++ b/R/config.R
@@ -29,6 +29,176 @@ parse_config <- function(config_path) {
   return(conf)
 }
 
+##### File Directory Function
+
+#' Creates file directories needed by the configuration file (.yml).
+#'
+#' @description The input is the parsed config file that the user will be using.
+#' It will take the parsed config to get the filepaths that need to be created to
+#' use the config file.
+#'
+#' @param config The parsed config file the function is creating the directory for.
+#' @param verbose A boolean variable that prints operational messages when set to TRUE.
+#' Obtained from `parse_config` function.
+create_file_directory <- function(conf, verbose = TRUE) {
+  # Create the git_repo folder
+  create_file_path(conf$version_control$log)
+
+  # Create the mailing_list directory, if needed
+  if (!is.null(conf$mailing_list)) {
+    # Check if there is mod_mbox
+    if (!is.null(conf$mailing_list$mod_mbox)) {
+      # Create for each project key
+      project_keys <- names(conf$mailing_list$mod_mbox)
+      for (key in project_keys) {
+        mailing_list <- conf$mailing_list$mod_mbox[[key]]
+        create_file_path(mailing_list$save_folder_path)
+      }
+    } else {
+      if (verbose) {
+        message("No mod_mbox found")
+      }
+    }
+    # Check if there is pipermail
+    if (!is.null(conf$mailing_list$pipermail)) {
+      # Create for each project key
+      project_keys <- names(conf$mailing_list$pipermail)
+      for (key in project_keys) {
+        mailing_list <- conf$mailing_list$pipermail[[key]]
+        create_file_path(mailing_list$save_folder_path)
+      }
+    } else {
+      if (verbose) {
+        message("No pipermail found")
+      }
+    }
+  } else {
+    if (verbose) {
+      message("No mailing_list found")
+    }
+  }
+
+  # Create the issue_tracker directory, if needed
+  if (!is.null(conf$issue_tracker)) {
+    # Check for jira
+    if (!is.null(conf$issue_tracker$jira)) {
+      # Create for each project key
+      project_keys <- names(conf$issue_tracker$jira)
+      for (key in project_keys) {
+        issue_tracker <- conf$issue_tracker$jira[[key]]
+        create_file_path(issue_tracker$issues)
+        create_file_path(issue_tracker$issue_comments)
+      }
+    } else {
+      if (verbose) {
+        message("No jira found")
+      }
+    }
+    # Check for github
+    if (!is.null(conf$issue_tracker$github)) {
+      # Create for each project key
+      project_keys <- names(conf$issue_tracker$github)
+      for (key in project_keys) {
+        issue_tracker <- conf$issue_tracker$github[[key]]
+        create_file_path(issue_tracker$issue_or_pr_comment)
+        create_file_path(issue_tracker$issue)
+        create_file_path(issue_tracker$issue_search)
+        create_file_path(issue_tracker$issue_event)
+        create_file_path(issue_tracker$pull_request)
+        create_file_path(issue_tracker$commit)
+      }
+    } else {
+      if (verbose) {
+        message("No github found")
+      }
+    }
+    # Check for bugzilla
+    if (!is.null(conf$issue_tracker$bugzilla)) {
+      # Create for each project key
+      project_keys <- names(conf$issue_tracker$bugzilla)
+      for (key in project_keys) {
+        issue_tracker <- conf$issue_tracker$bugzilla[[key]]
+        create_file_path(issue_tracker$issues)
+        create_file_path(issue_tracker$issue_comments)
+      }
+    } else {
+      if (verbose) {
+        message("No bugzilla found")
+      }
+    }
+  } else {
+    if (verbose) {
+      message("No issue_tracker found")
+    }
+  }
+
+  # Create the tools directory, if needed
+  if (!is.null(conf$tool)) {
+    # Check for dv8
+    if (!is.null(conf$tool$dv8)) {
+      create_file_path(conf$tool$dv8$folder_path)
+    } else {
+      if (verbose) {
+        message("dv8 is unused")
+      }
+    }
+    # Check for srcml
+    if (!is.null(conf$tool$srcml)) {
+      create_file_path(conf$tool$srcml$srcml_path)
+    } else {
+      if (verbose) {
+        message("srcml is unused")
+      }
+    }
+    # Check for pattern4
+    if (!is.null(conf$tool$pattern4)) {
+      create_file_path(conf$tool$pattern4$class_folder_path)
+      create_file_path(conf$tool$pattern4$output_filepath)
+    } else {
+      if (verbose) {
+        message("pattern4 is unused")
+      }
+    }
+    # Check for understand
+    if (!is.null(conf$tool$understand)) {
+      create_file_path(conf$tool$understand$project_path)
+      create_file_path(conf$tool$understand$output_path)
+    }
+  } else {
+    if (verbose) {
+      message("no tools used")
+    }
+  }
+}
+
+#' A helper function for `create_file_directory`.
+#'
+#' @description The function checks if a filepath exists on the local device.
+#' If the filepath does not exist, then the function creates it.
+#'
+#' @param filepath The filepath to create.
+#' @param verbose A boolean variable that prints the operational messages when set to TRUE.
+create_file_path <- function(filepath, verbose= TRUE) {
+  if (!is.null(filepath)) {
+    # Check if the filepath already exists
+    if (dir.exists(filepath)) {
+      if (verbose) {
+        message("Filepath: ", filepath, " already exists.")
+      }
+    } else {
+      # Create the filepath
+      dir.create(filepath, recursive= TRUE)
+      if (verbose) {
+        message("Created filepath: ", filepath)
+      }
+    }
+  } else {
+    if (verbose) {
+      message("Invalid filepath: ", filepath)
+    }
+  }
+}
+
 ##### Git Getter Functions #####
 
 #' Returns the path to the .git of the project repository that is being analyzed.

--- a/R/config.R
+++ b/R/config.R
@@ -29,17 +29,19 @@ parse_config <- function(config_path) {
   return(conf)
 }
 
-##### File Directory Function
+##### File Directory Function #####
 
 #' Creates file directories needed by the configuration file (.yml).
 #'
 #' @description The input is the parsed config file that the user will be using.
 #' It will take the parsed config to get the filepaths that need to be created to
-#' use the config file.
+#' use the config file. The function relies on the helper function `create_file_directory`
+#' to see if any of the directories already exist, and create those that don't.
 #'
 #' @param config The parsed config file the function is creating the directory for.
 #' @param verbose A boolean variable that prints operational messages when set to TRUE.
 #' Obtained from `parse_config` function.
+#' @export
 create_file_directory <- function(conf, verbose = TRUE) {
   # Create the git_repo folder
   create_file_path(conf$version_control$log)
@@ -106,6 +108,7 @@ create_file_directory <- function(conf, verbose = TRUE) {
         create_file_path(issue_tracker$issue_event)
         create_file_path(issue_tracker$pull_request)
         create_file_path(issue_tracker$commit)
+        create_file_path(issue_tracker$discussion)
       }
     } else {
       if (verbose) {
@@ -178,6 +181,7 @@ create_file_directory <- function(conf, verbose = TRUE) {
 #'
 #' @param filepath The filepath to create.
 #' @param verbose A boolean variable that prints the operational messages when set to TRUE.
+#' @export
 create_file_path <- function(filepath, verbose= TRUE) {
   if (!is.null(filepath)) {
     # Check if the filepath already exists

--- a/conf/ambari.yml
+++ b/conf/ambari.yml
@@ -82,25 +82,26 @@ issue_tracker:
       domain: https://issues.apache.org/jira
       project_key: AMBARI
       # Download using `download_jira_data.Rmd`
-      # issues: ../../rawdata/ambari/jira/issues/ambari/
-      # issue_comments: ../../rawdata/ambari/jira/issue_comments/ambari/
+      # issues: ../../rawdata/ambari/jira/ambari/issue/
+      # issue_comments: ../../rawdata/ambari/jira/ambari/issue_comments/
   github:
     project_key_1:
       # Obtained from the project's GitHub URL
       owner: apache
       repo: ambari
       # Download using `download_github_comments.Rmd`
-      issue_or_pr_comment: ../../rawdata/ambari/github/issue_or_pr_comment/apache_ambari/
-      issue: ../../rawdata/ambari/github/issue/apache_ambari/
-      issue_search: ../../rawdata/ambari/github/issue_search/apache_ambari/
-      issue_event: ../../rawdata/ambari/github/issue_event/apache_ambari/
-      pull_request: ../../rawdata/ambari/github/pull_request/apache_ambari/
-      commit: ../../rawdata/ambari/github/commit/apache_ambari/
+      issue_or_pr_comment: ../../rawdata/ambari/github/apache_ambari/issue_or_pr_comment/
+      issue: ../../rawdata/ambari/github/apache_ambari/issue/
+      issue_search: ../../rawdata/ambari/github/apache_ambari/issue_search/
+      issue_event: ../../rawdata/ambari/github/apache_ambari/issue_event/
+      pull_request: ../../rawdata/ambari/githubapache_ambari/pull_request/
+      pr_comments: ../../rawdata/kaiaulu/github/apache_ambari/pr_comments/
+      commit: ../../rawdata/ambari/github/apache_ambari/commit/
   # bugzilla:
   #   project_key_1:
   #     project_key: ambari
-  #     issues: ../../rawdata/ambari/bugzilla/issues/ambari/
-  #     issue_comments: ../../rawdata/ambari/bugzilla/issue_comments/ambari/
+  #     issues: ../../rawdata/ambari/bugzilla/ambari/issue
+  #     issue_comments: ../../rawdata/ambari/bugzilla/ambari/issue_comments/
 
 
 #vulnerabilities:

--- a/conf/apr.yml
+++ b/conf/apr.yml
@@ -75,36 +75,37 @@ issue_tracker:
   #     domain: https://issues.apache.org/jira
   #     project_key: HELIX
   #     # Download using `download_jira_data.Rmd`
-  #     issues: ../../rawdata/apr/jira/issues/helix/
-  #     issue_comments: ../../rawdata/apr/jira/issue_comments/helix/
+  #     issues: ../../rawdata/apr/jira/helix/issues/
+  #     issue_comments: ../../rawdata/apr/jira/helix/issue_comments/
   github:
     project_key_1:
       # Obtained from the project's GitHub URL
       owner: apache
       repo: apr
       # Download using `download_github_comments.Rmd`
-      issue_or_pr_comment: ../../rawdata/apr/github/issue_or_pr_comment/apache_apr/
-      issue: ../../rawdata/apr/github/issue/apache_apr/
-      issue_search: ../../rawdata/apr/github/issue_search/apache_apr/
-      issue_event: ../../rawdata/apr/github/issue_event/apache_apr/
-      pull_request: ../../rawdata/apr/github/pull_request/apache_apr/
-      commit: ../../rawdata/apr/github/commit/apache_apr/
+      issue_or_pr_comment: ../../rawdata/apr/github/apache_apr/issue_or_pr_comment/
+      issue: ../../rawdata/apr/github/apache_apr/issue/
+      issue_search: ../../rawdata/apr/github/apache_apr/issue_search/
+      issue_event: ../../rawdata/apr/github/apache_apr/issue_event/
+      pull_request: ../../rawdata/apr/github/apache_apr/pull_request/
+      pr_comments: ../../rawdata/apr/github/apache_apr/pr_comments/
+      commit: ../../rawdata/apr/github/apache_apr/commit/
 #     project_key_2:
 #       # Obtained from the project's GitHub URL
 #       owner: ssunoo2
 #       repo: kaiaulu
 #       # Download using `download_github_comments.Rmd`
-#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
-#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
-#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
-#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
-#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
-#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_or_pr_comment/
+#       issue: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue/
+#       issue_search: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_search/
+#       issue_event: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_event/
+#       pull_request: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/pull_request/
+#       commit: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/commit/
 #   bugzilla:
 #     project_key_1:
 #       project_key: kaiaulu
-#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
-#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+#       issues: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issues/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issue_comments/
 
 
 

--- a/conf/calculator.yml
+++ b/conf/calculator.yml
@@ -74,36 +74,37 @@ issue_tracker:
 #      domain: https://sailuh.atlassian.net
 #      project_key: SAILUH
 #      # Download using `download_jira_data.Rmd`
-#      issues: ../../rawdata/kaiaulu/jira/issues/sailuh/
-#      issue_comments: ../../rawdata/kaiaulu/jira/issue_comments/sailuh/
+#      issues: ../../rawdata/kaiaulu/jira/sailuh/issues/
+#      issue_comments: ../../rawdata/kaiaulu/jira/sailuh/issue_comments/
   github:
     project_key_1:
       # Obtained from the project's GitHub URL
       owner: HouariZegai
       repo: Calculator
       # Download using `download_github_comments.Rmd`
-      issue_or_pr_comment: ../../rawdata/Calculator/github/issue_or_pr_comment/HouariZegai_Calculator/
-      issue: ../../rawdata/Calculator/github/issue/HouariZegai_Calculator/
-      issue_search: ../../rawdata/Calculator/github/issue_search/HouariZegai_Calculator/
-      issue_event: ../../rawdata/Calculator/github/issue_event/HouariZegai_Calculator/
-      pull_request: ../../rawdata/Calculator/github/pull_request/HouariZegai_Calculator/
-      commit: ../../rawdata/Calculator/github/commit/HouariZegai_Calculator/
+      issue_or_pr_comment: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue_or_pr_comment/
+      issue: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue/
+      issue_search: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue_search/
+      issue_event: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue_event/
+      pull_request: ../../rawdata/Calculator/github/HouariZegai_Calculator/pull_request/
+      pr_comments: ../../rawdata/Calculator/github/HouariZegai_Calculator/pr_comments/
+      commit: ../../rawdata/Calculator/github/HouariZegai_Calculator/commit/
 #     project_key_2:
 #       # Obtained from the project's GitHub URL
 #       owner: ssunoo2
 #       repo: kaiaulu
 #       # Download using `download_github_comments.Rmd`
-#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
-#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
-#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
-#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
-#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
-#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_or_pr_comment/
+#       issue: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue/
+#       issue_search: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_search/
+#       issue_event: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_event/
+#       pull_request: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/pull_request/
+#       commit: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/commit/
 #   bugzilla:
 #     project_key_1:
 #       project_key: kaiaulu
-#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
-#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+#       issues: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issues/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issue_comments/
 
 #vulnerabilities:
   # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)

--- a/conf/camel.yml
+++ b/conf/camel.yml
@@ -96,17 +96,17 @@ issue_tracker:
 #       owner: ssunoo2
 #       repo: kaiaulu
 #       # Download using `download_github_comments.Rmd`
-#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
-#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
-#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
-#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
-#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
-#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_or_pr_comment/
+#       issue: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue/
+#       issue_search: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_search/
+#       issue_event: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_event/
+#       pull_request: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/pull_request/
+#       commit: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/commit/
 #   bugzilla:
 #     project_key_1:
 #       project_key: kaiaulu
-#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
-#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+#       issues: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issues/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issue_comments/
 
 #vulnerabilities:
   # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)

--- a/conf/kaiaulu.yml
+++ b/conf/kaiaulu.yml
@@ -87,23 +87,24 @@ issue_tracker:
       issue_search: ../../rawdata/kaiaulu/github/sailuh_kaiaulu/issue_search/
       issue_event: ../../rawdata/kaiaulu/github/sailuh_kaiaulu/issue_event/
       pull_request: ../../rawdata/kaiaulu/github/sailuh_kaiaulu/pull_request/
+      pr_comments: ../../rawdata/kaiaulu/github/sailuh_kaiaulu/pr_comments/
       commit: ../../rawdata/kaiaulu/github/sailuh_kaiaulu/commit/
 #     project_key_2:
 #       # Obtained from the project's GitHub URL
 #       owner: ssunoo2
 #       repo: kaiaulu
 #       # Download using `download_github_comments.Rmd`
-#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
-#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
-#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
-#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
-#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
-#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_or_pr_comment/
+#       issue: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue/
+#       issue_search: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_search/
+#       issue_event: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_event/
+#       pull_request: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/pull_request/
+#       commit: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/commit/
 #   bugzilla:
 #     project_key_1:
 #       project_key: kaiaulu
-#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
-#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+#       issues: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issues/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issue_comments/
 
 vulnerabilities:
   # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)

--- a/vignettes/download_github_comments.Rmd
+++ b/vignettes/download_github_comments.Rmd
@@ -12,10 +12,19 @@ vignette: >
 
 # Introduction
 
-
 In this Vignette, we show how to download GitHub comments from both Issue and Pull Requests. This data may be useful if development communication occurs through issues or pull requests in GitHub in addition or instead of mailing lists. For details on how to merge various communication sources, see the `reply_communication_showcase.Rmd` notebook. The parsed communication table from GitHub comments by `parse_github_comments` has the same format as the mailing list and JIRA comments tables. In turn, the function expects as input the table generated at the end of this notebook.
 
-This notebook assumes you are familiar with obtaining a GitHub token. For details, see the `github_api_showcase.Rmd` notebook. The functions in Kaiaulu will assume you have a token available, which can be passed as parameter. 
+The functions in Kaiaulu will assume you have a token available, which can be passed as parameter. 
+
+## Create a Personal Token 
+
+GitHub limits the number of API calls per IP to only 60 attempts **every hour** at the time this vignette was created. You can check the current rates at [its website](https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting).
+
+If using a personal account token from a free GitHub account, the number of API calls per hour increases to 5000 **per hour**. Therefore, it is recommended you create a personal token by following the [GitHub Documentation instructions](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#:~:text=Creating%20a%20token.%201%20Verify%20your%20email%20address%2C,able%20to%20see%20the%20token%20again.%20More%20items). The process should not take more than 2 minutes.
+
+## Libraries
+
+To use the notebook, you will need to ensure you have the required R packages installed.
 
 ```{r warning=FALSE,message=FALSE}
 rm(list = ls())
@@ -27,6 +36,28 @@ require(magrittr)
 require(gt)
 ```
 
+## Project Configuration File
+
+To use the pipeline, you must specify the organization and project of interest, and your token.
+
+```{r warning=FALSE}
+conf <- parse_config("../conf/kaiaulu.yml")
+owner <- get_github_owner(conf, "project_key_1") # Has to match github organization (e.g. github.com/sailuh)
+repo <- get_github_repo(conf, "project_key_1") # Has to match github repository (e.g. github.com/sailuh/perceive)
+
+# Path you wish to save all raw data.
+save_path_issue_refresh <- get_github_issue_search_path(conf, "project_key_1")
+save_path_issue <- get_github_issue_path(conf, "project_key_1")
+save_path_pull_request <- get_github_pull_request_path(conf, "project_key_1")
+save_path_pr_comments <- get_github_pr_comments_path(conf, "project_key_1")
+save_path_issue_or_pr_comments <- get_github_issue_or_pr_comment_path(conf, "project_key_1")
+save_path_commit <- get_github_commit_path(conf, "project_key_1")
+# Create all folder directories
+create_file_directory(conf)
+
+# your file github_token (a text file) contains the GitHub token API
+token <- scan("~/.ssh/github_token",what="character",quiet=TRUE)
+```
 
 # GitHub Project's Comments
 
@@ -36,31 +67,10 @@ Further details are noted on the issue endpoint: _'Note: GitHub's REST API v3 co
 
 While the above is true for **comments**, the first message of every issue and every pull request (which also include a title) is not regarded by GitHub as a comment. For example, suppose one issue was opened by Author A, and contain only one reply by Author B. In this case, A and B established communication, and we would like this interaction to be reflected in the final table. However, if we were to only use the **comments** endpoint, we would only obtain Author's B comment, and not Author's A. The same is true in Pull Requests.
 
-Therefore, in this Notebook we have to rely on three endpoints from the GitHub API: The `Issue endpoint` to obtain the "first comment" of every issue, the `Pull Request endpoint` to obtain the "first comment" of every pull request, then finally the `Issue and Pull Request Comment endpoint`, which provides comments for both issue and pull requests together.
-
-
-# Project Configuration File
-
-To use the pipeline, you must specify the organization and project of interest, and your token. Obtain a github token following the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
-
-```{r}
-conf <- parse_config("../conf/kaiaulu.yml")
-
-save_path_issue_refresh <- get_github_issue_search_path(conf, "project_key_1")
-save_path_issue <- get_github_issue_path(conf, "project_key_1")
-save_path_pull_request <- get_github_pull_request_path(conf, "project_key_1")
-save_path_issue_or_pr_comments <- get_github_issue_or_pr_comment_path(conf, "project_key_1")
-save_path_commit <- get_github_commit_path(conf, "project_key_1")
-# Path you wish to save all raw data. A folder with the repo name and sub-folders will be created.
-
-owner <- get_github_owner(conf, "project_key_1") # Has to match github organization (e.g. github.com/sailuh)
-repo <- get_github_repo(conf, "project_key_1") # Has to match github repository (e.g. github.com/sailuh/perceive)
-# your file github_token (a text file) contains the GitHub token API
-token <- scan("~/.ssh/github_token",what="character",quiet=TRUE)
-```
+Therefore, in this Notebook we have to rely on four endpoints from the GitHub API: The `Issue endpoint` to obtain the "first comment" of every issue, the `Pull Request endpoint` to obtain the "first comment" of every pull request, followed by the `Issue and Pull Request Comment endpoint`, which provides comments for both issue and pull requests together.
+Unfortunately, neither the `Pull Request endpoint` nor the `Issue and Pull Request Comment endpoint` retrieve in-line code comments from Pull Requests. For these, we need to rely on the fourth endpoint, `Pull Request Comment endpoint`.
 
 # Issues
-
 ## Issues by Date Range
 
 Kaiaulu offers the ability to download issue data by date range. Using the `github_api_project_issue_by_date()`, you can download issues based on their ['created'](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-when-an-issue-or-pull-request-was-created-or-last-updated) dates. The acceptable formats are:
@@ -86,20 +96,19 @@ If you would like to retrieve only issues **before** a certain date, set `date_l
 
 
 ```{r Collect issues by date x, eval = FALSE}
-created_lower_bound_issue <- "1990-01-01"
-created_upper_bound_issue <- "2021-01-01"
+created_lower_bound_issue <- "2024-12-01"
+created_upper_bound_issue <- NULL
 # make initial API CALL
 # Acceptable formats for issue_or_pr
 # "is:issue"
 # "is:pull-request
-# issue_or_pr <- "is:issue"
-issue_or_pr <- "is:pull-request"
+issue_or_pr <- "is:issue"
+#issue_or_pr <- "is:pull-request"
 if (issue_or_pr == "is:issue"){
   issue_date_save_path <- save_path_issue_refresh
 } else {
   issue_date_save_path <- save_path_pull_request
 }
-dir.create(issue_date_save_path)
 gh_response <- github_api_project_issue_by_date(owner,
                                                 repo,
                                                 token,
@@ -107,11 +116,8 @@ gh_response <- github_api_project_issue_by_date(owner,
                                                 created_upper_bound_issue,
                                                 issue_or_pr,
                                                 verbose=TRUE)
-#dir.create(save_path_issue)
 
 # Make subsequent API calls and write to JSON file along save path
-dir.create(save_path_issue_refresh)
-
 github_api_iterate_pages(token,gh_response,
                          issue_date_save_path,
                          prefix="issue",
@@ -124,7 +130,6 @@ all_issue_files <- lapply(list.files(save_path_issue_refresh, full.names = TRUE)
 
 # Parse each JSON file using the refresh parser
 all_issue <- lapply(all_issue_files, github_parse_search_issues_refresh)
-
 
 # Combine all the data tables
 all_issues_combined <- rbindlist(all_issue, fill = TRUE)
@@ -157,7 +162,6 @@ if (issue_or_pr == "is:issue"){
 gh_response <- github_api_project_issue_search(owner, repo, token, query, issue_or_pr, verbose=TRUE)
 
 # Make subsequent API calls and write to JSON file along save path
-
 github_api_iterate_pages(token,gh_response,
                          save_path_issue_refresh,
                          prefix="issue",
@@ -183,7 +187,6 @@ This function relies on the naming convention the downloaders utilize on the fil
 issue_or_pr <- "is:issue"
 # issue_or_pr <- "is:pull-request"
 # gh call but with date
-# dir.create(save_path_issue_refresh)
 if (issue_or_pr == "is:issue"){
   issue_date_save_path <- save_path_issue_refresh
 } else {
@@ -200,6 +203,7 @@ github_api_iterate_pages(token,gh_response,
                          prefix="issue",
                          verbose=TRUE)
 ```
+
 ```{r}
 # Read all JSON files from the directory
 all_issue_files <- lapply(list.files(save_path_issue_refresh, full.names = TRUE), read_json)
@@ -218,9 +222,9 @@ head(all_issues_combined) %>%
 
 The Refresh parser also parses issue data but the folder 'refresh_issues', parsing data retrieved from the search endpoint. In this notebook, that is data from the REFRESH issues portion saved to issue_search directory. 
 
-# Comments
 
-## Issues and Pull Requests Comments
+# Comments
+## Issues and PR Comments by Date Range
 
 Sometimes it is helpful to retrieve issue comments after a particular date. Issue comments have the drawback in the Github API of only being able to specify a lower bound and downloading all comments created or updated after this date inclusive. If there are multiple revisions of a comment, the most recent version of the comment is downloaded. The acceptable date formats are:
 
@@ -245,16 +249,13 @@ gh_response <- github_api_project_issue_or_pr_comments_by_date(owner = owner,
                                                 token = token,
                                                 since = updated_lower_bound_comment,
                                                 verbose=TRUE)
-#dir.create(save_path_issue_or_pr_comments)
+
 # Make subsequent API calls and write to JSON file along save path
-
-
 github_api_iterate_pages(token,gh_response,
                          save_path_issue_or_pr_comments,
                          prefix="issue",
                          verbose=TRUE)
 ```
-
 
 ```{r}
 all_issue_or_pr_comments <- lapply(list.files(save_path_issue_or_pr_comments,
@@ -290,9 +291,7 @@ github_api_iterate_pages(token,gh_response_issue_or_pr_comment,
                          verbose=TRUE)
 ```
 
-
-
-```{r}
+```{r Parse all issues comments}
 all_issue_or_pr_comments <- lapply(list.files(save_path_issue_or_pr_comments,
                                      full.names = TRUE),read_json)
 all_issue_or_pr_comments <- lapply(all_issue_or_pr_comments,
@@ -306,18 +305,17 @@ head(all_issue_or_pr_comments,2)  %>%
 
 # Other API Endpoints
 
-The following API endpoints do not currently implement the refresher, but may provide useful information. 
+The following API endpoints do not currently implement the refresher, but may provide useful information.
+The exception to this is the Pull Request Review Comments endpoint, which does implement a refresher.
 
 ## Commits Endpoint: Obtaining author's name and e-mail
 
-The three endpoints used before do not contain author and e-mail information, only the developers GitHub ids. This is a problem, if the project being studied contains communication data outside the GitHub ecosystem (e.g. uses JIRA as issue tracker). In order to link developers to other sources, we need both author and e-mail information.
+The four endpoints used before do not contain author and e-mail information, only the developers GitHub ids. This is a problem, if the project being studied contains communication data outside the GitHub ecosystem (e.g. uses JIRA as issue tracker). In order to link developers to other sources, we need both author and e-mail information.
 
 To do so, we can use the committer endpoint. 
 
-
 ```{r Collect all authors and committers name and e-mail, eval = FALSE}
 gh_response <- github_api_project_commits(owner,repo,token)
-dir.create(save_path_commit)
 github_api_iterate_pages(token,gh_response,
                          save_path_commit,
                          prefix="commit",
@@ -325,20 +323,19 @@ github_api_iterate_pages(token,gh_response,
 
 ```
 
-## Issue or PR Endpoint
+## Issue Endpoint
 
 The refresh search endpoint does **not** include pull requests. If the intent is to download both issues and pull requests, then the `/issue/` endpoint should be used instead:
 
 
 ```{r Collect all issues from issue endpoint, eval = FALSE}
 gh_response <- github_api_project_issue(owner,repo,token)
-dir.create(save_path_issue)
 github_api_iterate_pages(token,gh_response,
                          save_path_issue,
                          prefix="issue")
 ```
 
-```{r}
+```{r Parse all issues from issue endpoint}
 all_issue_or_pr <- lapply(list.files(save_path_issue,
                                      full.names = TRUE),read_json)
 all_issue_or_pr <- lapply(all_issue_or_pr,
@@ -354,19 +351,14 @@ head(all_issue_or_pr,2)  %>%
 
 Similarly to the Issue API, we can also obtain other metadata from pull requests, including their labels.
 
-```{r eval = FALSE}
-save_path_pull_request <- paste0(save_path,"/pull_request/")
-```
-
 ```{r Collect all pull requests, eval = FALSE}
 gh_response <- github_api_project_pull_request(owner,repo,token)
-dir.create(save_path_pull_request)
 github_api_iterate_pages(token,gh_response,
                          save_path_pull_request,
                          prefix="pull_request")
 ```
 
-```{r eval = FALSE}
+```{r Parse all pull requests, eval = FALSE}
 all_pr <- lapply(list.files(save_path_pull_request,
                                      full.names = TRUE),read_json)
 all_pr <- lapply(all_pr,
@@ -377,7 +369,22 @@ tail(all_pr,1)  %>%
   gt(auto_align = FALSE) 
 ```
 
+## Pull Request Review Comments Endpoint
 
+Other information we can obtain is the review comments from Pull Requests that contain the inline code blocks.
+
+```{r Collect Review Comments from Pull Requests}
+gh_response <- github_api_project_pr_comments_refresh(owner, repo, token)
+github_api_iterate_pages(token, gh_response, save_path_pr_comments, prefix="pr_comments")
+```
+
+```{r Parse Review Comments from Pull Requests}
+all_pr_comments <- lapply(list.files(save_path_pr_comments, full.names = TRUE), read_json)
+all_pr_comments <- lapply(all_pr_comments, github_parse_project_pr_comments)
+all_pr_comments <- rbindlist(all_pr_comments, fill = TRUE)
+head(all_pr_comments,100)  %>%
+  gt(auto_align = FALSE) 
+```
 
 ## Combining Issue and Pull Request communication
 
@@ -388,11 +395,12 @@ Note because we obtain the authors and committers name and e-mail, **only commen
 
 Below we show the result of such merge, including the name and e-mail fields obtained from the commit table. As before, we do not display the body column to prevent breaking the HTML format. 
 
-```{r}
+```{r Combine Issue and Pull Request Communication}
 replies <- parse_github_replies(save_path_issue,
                                 save_path_pull_request,
                                 save_path_issue_or_pr_comments,
-                                save_path_commit)  
+                                save_path_commit,
+                                save_path_pr_comments)  
 
 tail(replies,2)  %>%
   gt(auto_align = FALSE) 

--- a/vignettes/github_api_showcase.Rmd
+++ b/vignettes/github_api_showcase.Rmd
@@ -51,6 +51,8 @@ repo <- get_github_repo(conf, "project_key_1") # Has to match github repository 
 save_path_issue_or_pr_comments <- path.expand(get_github_issue_or_pr_comment_path(conf, "project_key_1"))
 save_path_issue_event <- get_github_issue_event_path(conf, "project_key_1")
 save_path_commit <- get_github_commit_path(conf, "project_key_1")
+# Create the necessary file directories
+create_file_directory(conf)
 # your file github_token contains the GitHub token API obtained in the steps above
 token <- scan("~/.ssh/github_token",what="character",quiet=TRUE)
 ```


### PR DESCRIPTION
Using the REST API to download review comments from Pull Requests using the `GET /repos/{owner}/{repo}/pulls/comments` endpoint.