### PR TITLE
368 Refactored src module execs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Authors@R: c(
     person('Ryan', 'Seng', role = c('ctb')),
     person('Raven', 'Quiddaoen', role= c('ctb')),
     person('Connor', 'Narowetz', role= c('ctb')),
-    person('Gerald', 'Huff', role= c('ctb'))
+    person('Gerald', 'Huff', role= c('ctb')),
+    person('Cohen', 'Ruport', role= c('ctb'))
     )
 Maintainer: Carlos Paradis <cvas@hawaii.edu>
 License: MPL-2.0 | file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ __kaiaulu 0.0.0.9700 (in development)__
 
 ### NEW FEATURES
 
+ * `exec/depends.R` has been added. It is an executable CLI to parse project dependencies using the Depends tool. [#368](https://github.com/sailuh/kaiaulu/issues/368)
+ * `exec/linemetrics.R` has been added. It is an executable CLI to analyze line metrics using SCC. [#368](https://github.com/sailuh/kaiaulu/issues/368)
+ * `exec/rdependencies.R` has been added. It is an executable CLI to parse project dependencies of R projects. [#368](https://github.com/sailuh/kaiaulu/issues/368)
+ * `exec/understand.R` has been added. It is an executable CLI to parse file and class dependencies using Scitool's Understand tool. [#368](https://github.com/sailuh/kaiaulu/issues/368)
  *  A new capability to export events for process mining has been added. [#301](https://github.com/sailuh/kaiaulu/issues/301)
  * `exec/ghevents.R` has been added. It is a executable CLI (command-line interface) to download and parse Github Issue Events from outside Kaiaulu.
  * All GitHub Pull Request Comments are able to be downloaded in the Pull Request Comments notebook. [342](https://github.com/sailuh/kaiaulu/issues/342)

--- a/exec/depends.R
+++ b/exec/depends.R
@@ -17,7 +17,13 @@ USAGE:
   depends.R parse <tools.yml> <project_conf.yml> <node_save_file_name_path> <edge_save_file_name_path>
 
 DESCRIPTION:
-  Parses file dependencies using the Depends tool.
+  Parses file dependencies using the Depends tool. Please see Kaiaulu's README.md for instructions on how to create <tool.yml> and <project_conf.yml>.
+
+ARGUMENTS:
+  <tools.yml>                   path to tools.yml file
+  <project_conf.yml>            path to configuration file for project you want to analyze
+  <node_save_file_name_path>    file path where csv of nodes of the network will be saved
+  <edge_save_file_name_path>    file path where csv of edges of the network will be saved
 
 OPTIONS:
   -h --help     Show this screen.

--- a/exec/depends.R
+++ b/exec/depends.R
@@ -1,0 +1,78 @@
+#!/usr/local/bin/Rscript
+
+require(kaiaulu, quietly = TRUE)
+require(data.table, quietly = TRUE)
+require(stringi, quietly = TRUE)
+require(gh, quietly = TRUE)
+require(yaml, quietly = TRUE)
+require(magrittr, quietly = TRUE)
+require(knitr, quietly = TRUE)
+require(cli, quietly = TRUE)
+
+doc <- "
+USAGE:
+  depends.R (-h | -help)
+  depends.R --version
+  depends.R parse help
+  depends.R parse <tools.yml> <project_conf.yml> <node_save_file_name_path> <edge_save_file_name_path>
+
+DESCRIPTION:
+  Parses file dependencies using the Depends tool.
+
+OPTIONS:
+  -h --help     Show this screen.
+  --version     Show version.
+"
+
+arguments <- docopt::docopt(doc, version = 'Kaiaulu 0.0.0.9700')
+
+# Determine which function to run and save output
+if (arguments[["parse"]] & arguments[["help"]]) {
+  cli::cli_alert_info("Parses a given GitHub project supplied by <project_conf.yml> and  saves two tables at the specified folders <node_save_file_name_path> <edge_save_file_name_path> using Depends")
+} else if (arguments[["parse"]]) {
+
+  tool <- parse_config(arguments[["<tools.yml>"]])
+  conf <- parse_config(arguments[["<project_conf.yml>"]])
+  git_repo_path <- get_git_repo_path(conf)
+
+  # Depends parameters
+  depends_jar_path <- get_tool_project("depends", tool)
+  language <- get_depends_code_language(conf)
+  keep_dependencies_type <- get_depends_keep_dependencies_type(conf)
+
+  # Filters
+  file_extensions <- get_file_extensions(conf)
+  substring_filepath <- get_substring_filepath(conf)
+
+  # Output
+  node_save_path <- arguments[["<node_save_file_name_path>"]]
+  edge_save_path <- arguments[["<edge_save_file_name_path>"]]
+
+  # Parse Dependencies
+  result <- parse_dependencies(depends_jar_path,git_repo_path,language=language)
+
+  # Filter Parsed Dependencies
+  result[["nodes"]] <- result[["nodes"]]  %>%
+    filter_by_file_extension(file_extensions,"filepath")  %>%
+    filter_by_filepath_substring(substring_filepath,"filepath")
+
+  result[["edgelist"]] <- result[["edgelist"]]  %>%
+    filter_by_file_extension(file_extensions,"src_filepath")  %>%
+    filter_by_file_extension(file_extensions,"dest_filepath")  %>%
+    filter_by_filepath_substring(substring_filepath,"src_filepath") %>%
+    filter_by_filepath_substring(substring_filepath,"dest_filepath")
+
+  # Write to Files
+  data.table::fwrite(result$nodes, node_save_path)
+  data.table::fwrite(result$edgelist, edge_save_path)
+  cli::cli_alert_success(paste0("Dependencies node table was saved at: ", node_save_path))
+  cli::cli_alert_success(paste0("Dependencies edge table was saved at: ", edge_save_path))
+
+} else if (arguments[["-h"]] || arguments[["--help"]]) {
+  cli::cli_alert_info(doc)
+} else if (arguments[["--version"]]) {
+  cli::cli_alert_info('Kaiaulu 0.0.0.9700')
+} else {
+  stop("No/invalid option(s) provided.")
+}
+

--- a/exec/linemetrics.R
+++ b/exec/linemetrics.R
@@ -1,0 +1,62 @@
+#!/usr/local/bin/Rscript
+
+require(kaiaulu, quietly = TRUE)
+require(data.table, quietly = TRUE)
+require(magrittr, quietly = TRUE)
+require(knitr, quietly = TRUE)
+require(cli, quietly = TRUE)
+
+doc <- "
+USAGE:
+  linemetrics.R (-h | -help)
+  linemetrics.R --version
+  linemetrics.R parse help
+  linemetrics.R parse <tools.yml> <project_conf.yml> <save_path>
+
+DESCRIPTION:
+  Analyze line metrics using the SCC tool.
+
+OPTIONS:
+  -h --help     Show this screen.
+  --version     Show version.
+"
+
+arguments <- docopt::docopt(doc, version = 'Kaiaulu 0.0.0.9700')
+
+# Determine which function to run and save output
+if (arguments[["parse"]] & arguments[["help"]]) {
+  cli::cli_alert_info("Parses a project specified in the <project_conf.yml> config file and returns a csv file designated by <save_path> using SCC")
+} else if (arguments[["parse"]]) {
+  tool <- parse_config(arguments[["<tools.yml>"]])
+  conf <- parse_config(arguments[["<project_conf.yml>"]])
+  scc_path <- get_tool_project("scc", tool)
+
+  git_repo_path <- get_git_repo_path(conf)
+  git_branch <- get_git_branches(conf)[1]
+
+  # Filters
+  file_extensions <- get_file_extensions(conf)
+  substring_filepath <- get_substring_filepath(conf)
+
+  # Output path
+  save_path <- arguments[["<save_path>"]]
+
+  git_checkout(git_branch,git_repo_path)
+
+  # Parse Dependencies
+  result <- parse_line_metrics(scc_path,git_repo_path)
+
+  # Filter Parsed Dependencies
+  result <- result  %>%
+    filter_by_file_extension(file_extensions,"Provider")  %>%
+    filter_by_filepath_substring(substring_filepath,"Provider")
+
+  data.table::fwrite(result, save_path)
+  cli::cli_alert_success(paste0("Line metrics table was saved at: ", save_path))
+} else if (arguments[["-h"]] || arguments[["--help"]]) {
+  cli::cli_alert_info(doc)
+} else if (arguments[["--version"]]) {
+  cli::cli_alert_info('Kaiaulu 0.0.0.9700')
+} else {
+  stop("No/invalid option(s) provided.")
+}

--- a/exec/linemetrics.R
+++ b/exec/linemetrics.R
@@ -14,7 +14,12 @@ USAGE:
   linemetrics.R parse <tools.yml> <project_conf.yml> <save_path>
 
 DESCRIPTION:
-  Analyze line metrics using the SCC tool.
+  Analyze line metrics using the SCC tool. Please see Kaiaulu's README.md for instructions on how to create <tool.yml> and <project_conf.yml>.
+
+ARGUMENTS:
+  <tools.yml>                   path to tools.yml file
+  <project_conf.yml>            path to configuration file for project you want to analyze
+  <save_path>                   file path where output will be saved
 
 OPTIONS:
   -h --help     Show this screen.

--- a/exec/rdependencies.R
+++ b/exec/rdependencies.R
@@ -1,0 +1,46 @@
+#!/usr/local/bin/Rscript
+
+require(kaiaulu, quietly = TRUE)
+require(cli, quietly = TRUE)
+require(XML, quietly = TRUE)
+require(stringi, quietly = TRUE)
+require(data.table, quietly = TRUE)
+
+doc <- "
+USAGE:
+  rdependencies.R (-h | -help)
+  rdependencies.R --version
+  rdependencies.R parse help
+  rdependencies.R parse <folder_path> <save_path>
+
+DESCRIPTION:
+  Analyzes a folder with R project files to return dependencies.
+
+OPTIONS:
+  -h --help     Show this screen.
+  --version     Show version.
+"
+
+arguments <- docopt::docopt(doc, version = 'Kaiaulu 0.0.0.9700')
+
+# Currently unsure how variables would work
+
+if (!arguments[["help"]]) {
+  folder_path <- arguments[["<folder_path>"]]
+  save_path <- arguments[["<save_path>"]]
+}
+
+# Determine which function to run and save output
+if (arguments[["parse"]] & arguments[["help"]]) {
+  cli::cli_alert_info("Analyzes dependencies using parse_r_dependencies() and saves it at the csv file specified in <save_path>")
+} else if (arguments[["parse"]]) {
+  result <- parse_r_dependencies(folder_path)
+  data.table::fwrite(result, save_path)
+  cli::cli_alert_success(paste0("Dependencies table was saved at: ", save_path))
+} else if (arguments[["-h"]] || arguments[["--help"]]) {
+  cli::cli_alert_info(doc)
+} else if (arguments[["--version"]]) {
+  cli::cli_alert_info('Kaiaulu 0.0.0.9700')
+} else {
+  stop("No/invalid option(s) provided.")
+}

--- a/exec/rdependencies.R
+++ b/exec/rdependencies.R
@@ -14,7 +14,11 @@ USAGE:
   rdependencies.R parse <folder_path> <save_path>
 
 DESCRIPTION:
-  Analyzes a folder with R project files to return dependencies.
+  Analyzes a folder with R project files to return dependencies. Please see Kaiaulu's README.md for instructions on how to create <tool.yml> and <project_conf.yml>.
+
+ARGUMENTS:
+  <folder_path>                     path to folder where your R project is stored
+  <save_path>                       file path where output will be saved
 
 OPTIONS:
   -h --help     Show this screen.

--- a/exec/understand.R
+++ b/exec/understand.R
@@ -1,0 +1,110 @@
+#!/usr/local/bin/Rscript
+
+require(kaiaulu, quietly = TRUE)
+require(cli, quietly = TRUE)
+require(XML, quietly = TRUE)
+require(stringi, quietly = TRUE)
+require(data.table, quietly = TRUE)
+
+doc <- "
+USAGE:
+  understand.R (-h | -help)
+  understand.R --version
+  understand.R build help
+  understand.R build <tools.yml> <project_conf.yml>
+  understand.R export help
+  understand.R export <tools.yml> <project_conf.yml> <save_path> (--class | --file)
+  understand.R parse help
+  understand.R parse <tools.yml> <project_conf.yml> <node_save_file_name_path> <edge_save_file_name_path> (--class | --file)
+
+DESCRIPTION:
+  Builds then analyzes a project using Scitool's Understand for dependencies between either classes or files.
+
+OPTIONS:
+  -h --help     Show this screen.
+  --version     Show version.
+  --class       parses class-level dependencies
+  --file        parses file-level dependencies
+"
+
+arguments <- docopt::docopt(doc, version = 'Kaiaulu 0.0.0.9700')
+
+if (!arguments[["help"]]) {
+  tool <- parse_config(arguments[["<tools.yml>"]])
+  scitools_path <- get_tool_project("scitools", tool)
+
+  conf <- parse_config(arguments[["<project_conf.yml>"]])
+  keep_dependencies_type <- get_understand_keep_dependencies_type(conf)
+  project_path <- get_understand_project_path(conf)
+
+  # Scitools
+  understand_folder <- get_understand_output_path(conf)
+  code_language <- get_understand_code_language(conf)
+
+  db_path <- stringi::stri_c(understand_folder,"Understand.und")
+
+  file_dependencies_path <- stringi::stri_c(understand_folder,"file_dependencies.xml")
+  class_dependencies_path <- stringi::stri_c(understand_folder,"class_dependencies.xml")
+
+  save_path <- arguments[["<save_path>"]]
+
+  node_save_path <- arguments[["<node_save_file_name_path>"]]
+  edge_save_path <- arguments[["<edge_save_file_name_path>"]]
+
+
+}
+
+# Determine which function to run and save output
+if (arguments[["build"]] & arguments[["help"]]) {
+  cli::cli_alert_info("Builds an analysis of the project in the designated project_path set in the <config_filepath.yml> using build_understand_project()")
+} else if (arguments[["export"]] & arguments[["help"]]) {
+  cli::cli_alert_info("From the built analysis, exports the dependency types of either files or classes (dependening on supplied flag) using export_understand_dependencies() and saves two xmls at the specified file paths: <node_save_file_name_path> <edge_save_file_name_path>")
+} else if (arguments[["parse"]] & arguments[["help"]]) {
+  cli::cli_alert_info("From the built analysis, parses the dependency types of either files or classes (dependening on supplied flag) using parse_understand_dependencies() and saves two csvs at the specified file paths: <node_save_file_name_path> <edge_save_file_name_path>")
+} else if (arguments[["build"]]) {
+  db_path <- build_understand_project(scitools_path = scitools_path,
+                                      project_path = project_path,
+                                      language = code_language,
+                                      output_dir = understand_folder)
+  cli::cli_alert_success("Project sucessfully built.")
+} else if (arguments[["export"]]) {
+  if (arguments[["--file"]]) {
+    result <- export_understand_dependencies(scitools_path = scitools_path,
+                                             db_filepath = db_path,
+                                             parse_type = "file",
+                                             output_filepath = save_path)
+  } else if (arguments[["--class"]]) {
+    result <- export_understand_dependencies(scitools_path = scitools_path,
+                                             db_filepath = db_path,
+                                             parse_type = "class",
+                                             output_filepath = save_path)
+  } else {
+    stop("No/invalid option(s) provided.")
+  }
+  cli::cli_alert_success(paste0("Dependencies xml was saved at: ", save_path))
+} else if (arguments[["parse"]]) {
+  if (arguments[["--file"]]) {
+    result <- parse_understand_dependencies(dependencies_path = file_dependencies_path)
+
+    data.table::fwrite(result$node_list, node_save_path)
+    data.table::fwrite(result$edge_list, edge_save_path)
+
+  } else if (arguments[["--class"]]) {
+    result <- parse_understand_dependencies(dependencies_path = class_dependencies_path)
+
+    data.table::fwrite(result$node_list, node_save_path)
+    data.table::fwrite(result$edge_list, edge_save_path)
+  } else {
+    stop("No/invalid option(s) provided.")
+  }
+
+  cli::cli_alert_success(paste0("Dependencies node table was saved at: ", node_save_path))
+  cli::cli_alert_success(paste0("Dependencies edge table was saved at: ", edge_save_path))
+
+} else if (arguments[["-h"]] || arguments[["--help"]]) {
+  cli::cli_alert_info(doc)
+} else if (arguments[["--version"]]) {
+  cli::cli_alert_info('Kaiaulu 0.0.0.9700')
+} else {
+  stop("No/invalid option(s) provided.")
+}

--- a/exec/understand.R
+++ b/exec/understand.R
@@ -18,13 +18,25 @@ USAGE:
   understand.R parse <tools.yml> <project_conf.yml> <node_save_file_name_path> <edge_save_file_name_path> (--class | --file)
 
 DESCRIPTION:
-  Builds then analyzes a project using Scitool's Understand for dependencies between either classes or files.
+  Builds then analyzes a project using Scitool's Understand for dependencies between either classes or files. Please see Kaiaulu's README.md for instructions on how to create <tool.yml> and <project_conf.yml>.
+
+COMMANDS:
+  build                         Builds an analysis of the project in the designated project_path set in the <project_conf.yml>
+  export                        Exports the dependencies to an xml
+  parse.                        Parses the dependencies and saves them to a node csv and an edge csv
+
+ARGUMENTS:
+  <tools.yml>                   path to tools.yml file
+  <project_conf.yml>            path to configuration file for project you want to analyze
+  <save_path>                   file path where output will be saved
+  <node_save_file_name_path>    file path where csv of nodes of the network will be saved
+  <edge_save_file_name_path>    file path where csv of edges of the network will be saved
 
 OPTIONS:
   -h --help     Show this screen.
   --version     Show version.
-  --class       parses class-level dependencies
-  --file        parses file-level dependencies
+  --class       parses/exports class-level dependencies
+  --file        parses/exports file-level dependencies
 "
 
 arguments <- docopt::docopt(doc, version = 'Kaiaulu 0.0.0.9700')
@@ -56,9 +68,9 @@ if (!arguments[["help"]]) {
 
 # Determine which function to run and save output
 if (arguments[["build"]] & arguments[["help"]]) {
-  cli::cli_alert_info("Builds an analysis of the project in the designated project_path set in the <config_filepath.yml> using build_understand_project()")
+  cli::cli_alert_info("Builds an analysis of the project in the designated project_path set in the <project_conf.yml> using build_understand_project()")
 } else if (arguments[["export"]] & arguments[["help"]]) {
-  cli::cli_alert_info("From the built analysis, exports the dependency types of either files or classes (dependening on supplied flag) using export_understand_dependencies() and saves two xmls at the specified file paths: <node_save_file_name_path> <edge_save_file_name_path>")
+  cli::cli_alert_info("From the built analysis, exports the dependency types of either files or classes (dependening on supplied flag) using export_understand_dependencies() and saves an xml of the dependencies at the specified file path: <save_path>")
 } else if (arguments[["parse"]] & arguments[["help"]]) {
   cli::cli_alert_info("From the built analysis, parses the dependency types of either files or classes (dependening on supplied flag) using parse_understand_dependencies() and saves two csvs at the specified file paths: <node_save_file_name_path> <edge_save_file_name_path>")
 } else if (arguments[["build"]]) {


### PR DESCRIPTION
Refactored execs from PR #329 for the understands, depends, kaiaulu_architecture, and line_metrics notebooks. Fixed issues with filters, save paths, readability, and consistency. Changes/logic fully described in issue #368. 

Co-authored-by: Raven Quiddaoen