### PR TITLE
376 refactor mail jira reply notebook config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Authors@R: c(
     person('Ryan', 'Seng', role = c('ctb')),
     person('Raven', 'Quiddaoen', role= c('ctb')),
     person('Connor', 'Narowetz', role= c('ctb')),
-    person('Gerald', 'Huff', role= c('ctb'))
+    person('Gerald', 'Huff', role= c('ctb')),
+    person('Giyoung(Michelle)', 'Back', role = c('ctb'))
     )
 Maintainer: Carlos Paradis <cvas@hawaii.edu>
 License: MPL-2.0 | file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ __kaiaulu 0.0.0.9700 (in development)__
 
 ### NEW FEATURES
 
+ * Refactored Mail, Jira, and Reply Communication notebooks to use separate project and analysis configuration files. [#376](https://github.com/sailuh/kaiaulu/issues/376)
  *  A new capability to export events for process mining has been added. [#301](https://github.com/sailuh/kaiaulu/issues/301)
  * `exec/ghevents.R` has been added. It is a executable CLI (command-line interface) to download and parse Github Issue Events from outside Kaiaulu.
  * All GitHub Pull Request Comments are able to be downloaded in the Pull Request Comments notebook. [342](https://github.com/sailuh/kaiaulu/issues/342)

--- a/conf/analysisE.yml
+++ b/conf/analysisE.yml
@@ -1,0 +1,148 @@
+# -*- yaml -*-
+# Analysis specific configuration (geronimo)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+  remove_filepaths_on_commit_size_greather_than:
+    - 30
+
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: java
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  dv8:
+    # The project folder path to store various intermediate
+    # files for DV8 Analysis
+    # The folder name will be used in the file names.
+    folder_path: ../../analysis/geronimo/dv8/
+    # the architectural flaws thresholds that should be used
+    architectural_flaws:
+      cliqueDepends:
+        - call
+        - use
+      crossingCochange: 2
+      crossingFanIn: 4
+      crossingFanOut: 4
+      mvCochange: 2
+      uiCochange: 2
+      uihDepends:
+        - call
+        - use
+      uihInheritance:
+        - extend
+        - implement
+        - public
+        - private
+        - virtual
+      uiHistoryImpact: 10
+      uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+      c:
+        - f # function definition
+      cpp:
+        - c # classes
+        - f # function definition
+      java:
+        - c # classes
+        - m # methods
+      python:
+        - c # classes
+        - f # functions
+      r:
+        - f # functions
+  # # srcML allow to parse src code as text (e.g. identifiers)
+  # srcml:
+  #   # The file path to where you wish to store the srcml output of the project
+  #   srcml_path: ../../analysis/junit5/srcml/srcml_junit.xml
+  # pattern4:
+  #   # The file path to where you wish to store the classes of the pattern4 analysis
+  #   class_folder_path: ../../rawdata/junit5/pattern4/classes/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  #   # The file path to where you wish to store the output of the pattern4 analysis
+  #  output_filepath: ../../analysis/junit5/pattern4/
+  #   compile_note: >
+  #     1. Switch Java version to Java 17:
+  #        https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+  #     2. Disable VPN to pull modules from Gradle Plugin Portal.
+  #     3. Use sudo ./gradlew build
+  #     4. After building, locate the engine class files and specify as the class_folder_path:
+  #        in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  # topics:
+    # topic_1:
+      # - Parser
+      # - Lexer
+    # topic_2:
+      # - Python
+      # - Ruby
+  # You can specify the intervals in 2 ways: window, or enumeration
+  window:
+    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+    #start_commit: 9eae9e96f15e1f216162810cef4271a439a74223
+    #end_commit: f8f9ec1f249dd552065aa37c983bed4d4d869bb0
+    # Use datetime only if no gitlog is used in the analysis.
+    #start_datetime: 2013-05-01 00:00:00
+    #end_datetime: 2013-11-01 00:00:00
+    #size_days: 90
+#  enumeration:
+     # If using gitlog, specify the commits
+#    commit:
+#      - 9eae9e96f15e1f216162810cef4271a439a74223
+#      - f1d2d568776b3708dd6a3077376e2331f9268b04
+#      - c33a2ce74c84f0d435bfa2dd8953d132ebf7a77a
+     # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/analysisI.yml
+++ b/conf/analysisI.yml
@@ -1,0 +1,148 @@
+# -*- yaml -*-
+# Analysis specific configuration (openssl)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+  # remove_filepaths_on_commit_size_greather_than:
+    # - 30
+
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: cpp
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  # dv8:
+  #   # The project folder path to store various intermediate
+  #   # files for DV8 Analysis
+  #   # The folder name will be used in the file names.
+  #   folder_path: ../../analysis/junit/dv8/
+  #   # the architectural flaws thresholds that should be used
+  #   architectural_flaws:
+  #     cliqueDepends:
+  #       - call
+  #       - use
+  #     crossingCochange: 2
+  #     crossingFanIn: 4
+  #     crossingFanOut: 4
+  #     mvCochange: 2
+  #     uiCochange: 2
+  #     uihDepends:
+  #       - call
+  #       - use
+  #     uihInheritance:
+  #       - extend
+  #       - implement
+  #       - public
+  #       - private
+  #       - virtual
+  #     uiHistoryImpact: 10
+  #     uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+      c:
+        - f # function definition
+      cpp:
+        - c # classes
+        - f # function definition
+      java:
+        - c # classes
+        - m # methods
+      python:
+        - c # classes
+        - f # functions
+      r:
+        - f # functions
+  # # srcML allow to parse src code as text (e.g. identifiers)
+  # srcml:
+  #   # The file path to where you wish to store the srcml output of the project
+  #   srcml_path: ../../analysis/junit5/srcml/srcml_junit.xml
+  # pattern4:
+  #   # The file path to where you wish to store the classes of the pattern4 analysis
+  #   class_folder_path: ../../rawdata/junit5/pattern4/classes/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  #   # The file path to where you wish to store the output of the pattern4 analysis
+  #  output_filepath: ../../analysis/junit5/pattern4/
+  #   compile_note: >
+  #     1. Switch Java version to Java 17:
+  #        https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+  #     2. Disable VPN to pull modules from Gradle Plugin Portal.
+  #     3. Use sudo ./gradlew build
+  #     4. After building, locate the engine class files and specify as the class_folder_path:
+  #        in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  # topics:
+    # topic_1:
+      # - Parser
+      # - Lexer
+    # topic_2:
+      # - Python
+      # - Ruby
+  # You can specify the intervals in 2 ways: window, or enumeration
+  window:
+    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+    #start_commit: 9eae9e96f15e1f216162810cef4271a439a74223
+    #end_commit: f8f9ec1f249dd552065aa37c983bed4d4d869bb0
+    # Use datetime only if no gitlog is used in the analysis.
+    #start_datetime: 2013-05-01 00:00:00
+    #end_datetime: 2013-11-01 00:00:00
+    size_days: 90
+#  enumeration:
+     # If using gitlog, specify the commits
+#    commit:
+#      - 9eae9e96f15e1f216162810cef4271a439a74223
+#      - f1d2d568776b3708dd6a3077376e2331f9268b04
+#      - c33a2ce74c84f0d435bfa2dd8953d132ebf7a77a
+     # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/geronimo_project.yml
+++ b/conf/geronimo_project.yml
@@ -1,0 +1,119 @@
+# -*- yaml -*-
+# Immutable data configuration (geronimo)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  website: https://geronimo.apache.org
+  openhub: https://www.openhub.net/p/geronimo
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  log: ../../rawdata/geronimo/git_repo/.git
+  # From where the git log was downloaded?
+  log_url: https://github.com/apache/geronimo
+  # List of branches used for analysis
+  branch:
+    - trunk
+
+mailing_list:
+  mod_mbox:
+    project_key_1:
+      mailing_list: http://mail-archives.apache.org/mod_mbox/geronimo-dev
+      save_folder_path: ../../rawdata/geronimo/mod_mbox/save_mbox_mail/
+      # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#      mbox_file_path: ../../rawdata/geronimo/mod_mbox/save_mbox_mail/geronimo.mbox
+    project_key_2:
+      mailing_list: http://mail-archives.apache.org/mod_mbox/geronimo-user
+      save_folder_path: ../../rawdata/geronimo/mod_mbox/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/kaiaulu.mbox
+#   pipermail:
+#     project_key_1:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-dev/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-users/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/kaiaulu.mbox
+
+issue_tracker:
+  jira:
+    project_key_1:
+      # Obtained from the project's JIRA URL
+      domain: https://issues.apache.org/jira
+      project_key: GERONIMO
+      # Download using `download_jira_data.Rmd`
+      issues: ../../rawdata/geronimo/jira/issues/
+      issue_comments: ../../rawdata/geronimo/jira/issue_comments/
+  github:
+    project_key_1:
+      # Obtained from the project's GitHub URL
+      owner: apache
+      repo: geronimo
+      # Download using `download_github_comments.Rmd`
+      issue_or_pr_comment: ../../rawdata/geronimo/github/issue_or_pr_comment/apache_geronimo/
+      issue: ../../rawdata/geronimo/github/issue/apache_geronimo/
+      issue_search: ../../rawdata/geronimo/github/issue_search/apache_geronimo/
+      issue_event: ../../rawdata/geronimo/github/issue_event/apache_geronimo/
+      pull_request: ../../rawdata/geronimo/github/pull_request/apache_geronimo/
+      commit: ../../rawdata/geronimo/github/commit/apache_geronimo/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+
+#vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  #nvd_feed: rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+commit_message_id_regex:
+  issue_id: GERONIMO-[0-9]+
+  #cve_id: ?

--- a/conf/openssl_project.yml
+++ b/conf/openssl_project.yml
@@ -1,0 +1,102 @@
+# -*- yaml -*-
+# Immutable data configuration (openssl)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  website: https://github.com/openssl/openssl
+  openhub: https://www.openhub.net/p/openssl
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  log: ../../rawdata/openssl/git_repo/.git
+  # From where the git log was downloaded?
+  log_url: https://github.com/openssl/openssl
+  # List of branches used for analysis
+  branch:
+    - 3f5ea7dc0ca4affb1fbe5c9f6d25add8aa3535b3
+    - master
+
+mailing_list:
+  pipermail:
+    project_key_1:
+      mailing_list: https://mta.openssl.org/pipermail/openssl-users/
+      save_folder_path: ../../rawdata/openssl/pipermail/save_mbox_users
+
+# issue_tracker:
+#   jira:
+#     project_key_1:
+#       # Obtained from the project's JIRA URL
+#       domain: https://sailuh.atlassian.net
+#       project_key: SAILUH
+#       # Download using `download_jira_data.Rmd`
+#       issues: ../../rawdata/kaiaulu/jira/issues/sailuh/
+#       issue_comments: ../../rawdata/kaiaulu/jira/issue_comments/sailuh/
+#   github:
+#     project_key_1:
+#       # Obtained from the project's GitHub URL
+#       owner: sailuh
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/sailuh_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/sailuh_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/sailuh_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/sailuh_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/sailuh_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/sailuh_kaiaulu/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+
+vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  nvd_feed: rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+commit_message_id_regex:
+  #issue_id: ?
+  cve_id: CVE-[0-9]+-[0-9]+

--- a/vignettes/download_jira_issues.Rmd
+++ b/vignettes/download_jira_issues.Rmd
@@ -45,26 +45,38 @@ To try out this Notebook, try the geronimo configuration file, and follow along 
 First, we will load the Kaiaulu configuration file:
 
 ```{r}
-conf <- parse_config("../conf/kaiaulu.yml")
+# conf <- parse_config("../conf/kaiaulu.yml")
+# conf <- parse_config("../conf/geronimo.yml")
+
+# Reads 2 configs
+project <- parse_config("../conf/geronimo_project.yml")
+# analysis <- parse_config("../conf/analysisE.yml")
+
+# Used for project.yml
+issue_tracker_domain <- get_jira_domain(project, "project_key_1")
+issue_tracker_project_key <- get_jira_project_key_name(project, "project_key_1")
+save_path_issue_tracker_issues <- get_jira_issues_path(project, "project_key_1")
+save_path_issue_tracker_issue_comments <- get_jira_issues_comments_path(project, "project_key_1")
+refresh_issues <- get_jira_issues_path(project, "project_key_1")
 
 # Project domain
 # Specify project_key_index in get_jira_domain() (e.g. "project_key_1")
-issue_tracker_domain <- get_jira_domain(conf, "project_key_1")
+# issue_tracker_domain <- get_jira_domain(conf, "project_key_1")
 
 # Project key
 # Specify project_key_index in get_jira_project_key_name() (e.g. "project_key_1")
-issue_tracker_project_key <- get_jira_project_key_name(conf, "project_key_1")
+# issue_tracker_project_key <- get_jira_project_key_name(conf, "project_key_1")
 
 # Altered save paths. Important for naming conventions
 # Specify project_key_index in get_jira_issues_path() (e.g. "project_key_1")
-save_path_issue_tracker_issues <- get_jira_issues_path(conf, "project_key_1")
+# save_path_issue_tracker_issues <- get_jira_issues_path(conf, "project_key_1")
 
 # Specify project_key_index in get_jira_issues_comments_path() (e.g. "project_key_1")
-save_path_issue_tracker_issue_comments <- get_jira_issues_comments_path(conf, "project_key_1")
+# save_path_issue_tracker_issue_comments <- get_jira_issues_comments_path(conf, "project_key_1")
 
 # Unaltered save paths from config file for use with refresh function
 # Specify project_key_index in get_jira_issues_path() (e.g. "project_key_1")
-refresh_issues <- get_jira_issues_path(conf, "project_key_1")
+# refresh_issues <- get_jira_issues_path(conf, "project_key_1")
 ```
 
 If authentication is needed, save your username (e-mail) and password (API token) in a file, e.g. atlassian_credentials, where the first line is the username, and the second the API token, e.g.

--- a/vignettes/download_mail.Rmd
+++ b/vignettes/download_mail.Rmd
@@ -87,8 +87,13 @@ tools <- parse_config("../tools.yml")
 parse_perceval_path <- get_tool_project("perceval", tools)
 
 # Load project configuration
-conf <- parse_config("../conf/helix.yml")
-mbox_file_path <- get_mbox_path(conf, "project_key_1")
+# conf <- parse_config("../conf/helix.yml")
+# mbox_file_path <- get_mbox_path(conf, "project_key_1")
+
+# Reads 2 configs
+project <- parse_config("../conf/helix_project.yml")
+# analysis <- parse_config("../conf/analysisF.yml")
+mbox_file_path <- get_mbox_path(project, "project_key_1")
 ```
 
 # Downloaders and Refreshers
@@ -104,9 +109,15 @@ For Pipermail, we need to specify the project key, which is used to retrieve the
 Now, we can use the getter functions to retrieve the configuration parameters for the specified project key.
 
 ```{r}
-conf <- parse_config("../conf/openssl.yml")
-pipermail_mailing_list <- get_pipermail_domain(conf, "project_key_1")
-pipermail_save_folder_path <- get_pipermail_path(conf, "project_key_1")
+# conf <- parse_config("../conf/openssl.yml")
+# pipermail_mailing_list <- get_pipermail_domain(conf, "project_key_1")
+# pipermail_save_folder_path <- get_pipermail_path(conf, "project_key_1")
+
+# Reads 2 configs
+project <- parse_config("../conf/openssl_project.yml")
+# analysis <- parse_config("../conf/analysisI.yml")
+pipermail_mailing_list <- get_pipermail_domain(project, "project_key_1")
+pipermail_save_folder_path <- get_pipermail_path(project, "project_key_1")
 
 # Define the date range
 pipermail_start_year_month <- 202310
@@ -145,9 +156,13 @@ parsed_mail %>%
 The download_mod_mbox() function downloads Mod Mbox archives from a specified Apache Pony Mail mailing list over a given date range. We obtain the required parameters from the project configuration file, as done before:
 
 ```{r eval=FALSE}
-conf <- parse_config("../conf/helix.yml")
-mbox_mailing_list <- get_mbox_domain(conf, "project_key_1")
-mbox_save_folder_path <- get_mbox_path(conf, "project_key_1")
+# conf <- parse_config("../conf/helix.yml")
+# mbox_mailing_list <- get_mbox_domain(conf, "project_key_1")
+# mbox_save_folder_path <- get_mbox_path(conf, "project_key_1")
+
+project <- parse_config("../conf/helix_project.yml")
+mbox_mailing_list <- get_mbox_domain(project, "project_key_1")
+mbox_save_folder_path <- get_mbox_path(project, "project_key_1")
 
 # Define the date range
 mbox_start_year_month <- 202310

--- a/vignettes/reply_communication_showcase.Rmd
+++ b/vignettes/reply_communication_showcase.Rmd
@@ -30,10 +30,16 @@ Load config file.
 
 ```{r}
 tool <- parse_config("../tools.yml")
-conf <- parse_config("../conf/helix.yml")
+# conf <- parse_config("../conf/helix.yml")
 perceval_path <- get_tool_project("perceval", tool)
-mbox_path <- get_mbox_path(conf, "project_key_1")
-jira_issue_comments_path <- get_jira_issues_comments_path(conf, "project_key_1")
+# mbox_path <- get_mbox_path(conf, "project_key_1")
+# jira_issue_comments_path <- get_jira_issues_comments_path(conf, "project_key_1")
+
+# Reads 2 configs
+project <- parse_config("../conf/helix_project.yml")
+# analysis <- parse_config("../conf/analysisF.yml")
+mbox_path <- get_mbox_path(project, "project_key_1")
+jira_issue_comments_path <- get_jira_issues_comments_path(project, "project_key_1")
 ```
 
 


### PR DESCRIPTION
## Purpose

Refactoring mail, jira, and reply configurations into taking 2 configurations (project vs analysis), more details in issue #376 .

## New Implementations

Project: Configurations that typically do not change between analyses

- geronimo_project.yml
- openssl_project.yml

Analysis Specific: Configurations that do change depending on the analysis

- analysisE.yml

- analysisI.yml

 Changed Notebooks: These notebooks now read 2 configs
- download_jira_issue.Rmd
- download_mail.Rmd
- reply_communication_showcase.Rmd

Example
Before: 
conf <- parse_config("../conf/geronimo.yml")

After: 
project <- parse_config("../conf/geronimo_project.yml")
analysis <- parse_config("../conf/analysisE.yml")