### PR TITLE
397 refactor full config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Authors@R: c(
     person('Ryan', 'Seng', role = c('ctb')),
     person('Raven', 'Quiddaoen', role= c('ctb')),
     person('Connor', 'Narowetz', role= c('ctb')),
-    person('Gerald', 'Huff', role= c('ctb'))
+    person('Gerald', 'Huff', role= c('ctb')),
+    person('Giyoung(Michelle)', 'Back', role = c('ctb'))
     )
 Maintainer: Carlos Paradis <cvas@hawaii.edu>
 License: MPL-2.0 | file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,7 @@ __kaiaulu 0.0.0.9700 (in development)__
 
 ### NEW FEATURES
 
- * Refactored Gitlog notebooks to use separate project and analysis configuration files. [#359](https://github.com/sailuh/kaiaulu/issues/359)
- * Refactored Depends, Understand, and Line Metrics notebooks to use separate project and analysis configuration files. Refactored kaiaulu_architecture.Rmd to derive the R source folder from the project configuration git path. [#366](https://github.com/sailuh/kaiaulu/issues/366)
- * Refactored Mail, Jira, and Reply Communication notebooks to use separate project and analysis configuration files. [#376](https://github.com/sailuh/kaiaulu/issues/376)
+ * Refactored Bug Count notebook to use separate project and analysis configuration files. [#387](https://github.com/sailuh/kaiaulu/issues/387)
  * Added remaining project and analysis configuration files for the full configuration refactor. [#397](https://github.com/sailuh/kaiaulu/issues/397)
  *  A new capability to export events for process mining has been added. [#301](https://github.com/sailuh/kaiaulu/issues/301)
  * `exec/ghevents.R` has been added. It is a executable CLI (command-line interface) to download and parse Github Issue Events from outside Kaiaulu.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ __kaiaulu 0.0.0.9700 (in development)__
 
 ### NEW FEATURES
 
+ * Refactored Gitlog notebooks to use separate project and analysis configuration files. [#359](https://github.com/sailuh/kaiaulu/issues/359)
+ * Refactored Depends, Understand, and Line Metrics notebooks to use separate project and analysis configuration files. Refactored kaiaulu_architecture.Rmd to derive the R source folder from the project configuration git path. [#366](https://github.com/sailuh/kaiaulu/issues/366)
+ * Refactored Mail, Jira, and Reply Communication notebooks to use separate project and analysis configuration files. [#376](https://github.com/sailuh/kaiaulu/issues/376)
+ * Added remaining project and analysis configuration files for the full configuration refactor. [#397](https://github.com/sailuh/kaiaulu/issues/397)
  *  A new capability to export events for process mining has been added. [#301](https://github.com/sailuh/kaiaulu/issues/301)
  * `exec/ghevents.R` has been added. It is a executable CLI (command-line interface) to download and parse Github Issue Events from outside Kaiaulu.
  * All GitHub Pull Request Comments are able to be downloaded in the Pull Request Comments notebook. [342](https://github.com/sailuh/kaiaulu/issues/342)

--- a/conf/analysisB.yml
+++ b/conf/analysisB.yml
@@ -1,0 +1,147 @@
+# -*- yaml -*-
+# Analysis specific configuration (calculator)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+  remove_filepaths_on_commit_size_greather_than:
+    - 300 # Calculator is a toy project, hence co-change threshold is set high to allow for migrations.
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: java
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  dv8:
+    # The project folder path to store various intermediate
+    # files for DV8 Analysis
+    # The folder name will be used in the file names.
+    folder_path: ../../analysis/Calculator/dv8/
+    # the architectural flaws thresholds that should be used
+    architectural_flaws:
+      cliqueDepends:
+        - call
+        - use
+      crossingCochange: 2
+      crossingFanIn: 4
+      crossingFanOut: 4
+      mvCochange: 2
+      uiCochange: 2
+      uihDepends:
+        - call
+        - use
+      uihInheritance:
+        - extend
+        - implement
+        - public
+        - private
+        - virtual
+      uiHistoryImpact: 10
+      uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+      c:
+        - f # function definition
+      cpp:
+        - c # classes
+        - f # function definition
+      java:
+        - c # classes
+        - m # methods
+      python:
+        - c # classes
+        - f # functions
+      r:
+        - f # functions
+  # # srcML allow to parse src code as text (e.g. identifiers)
+  # srcml:
+  #   # The file path to where you wish to store the srcml output of the project
+  #   srcml_path: ../../analysis/junit5/srcml/srcml_junit.xml
+  # pattern4:
+  #   # The file path to where you wish to store the classes of the pattern4 analysis
+  #   class_folder_path: ../../rawdata/junit5/pattern4/classes/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  #   # The file path to where you wish to store the output of the pattern4 analysis
+  #  output_filepath: ../../analysis/junit5/pattern4/
+  #   compile_note: >
+  #     1. Switch Java version to Java 17:
+  #        https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+  #     2. Disable VPN to pull modules from Gradle Plugin Portal.
+  #     3. Use sudo ./gradlew build
+  #     4. After building, locate the engine class files and specify as the class_folder_path:
+  #        in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  # topics:
+    # topic_1:
+      # - Parser
+      # - Lexer
+    # topic_2:
+      # - Python
+      # - Ruby
+  # You can specify the intervals in 2 ways: window, or enumeration
+  window:
+    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+    start_commit: 9eae9e96f15e1f216162810cef4271a439a74223
+    end_commit: f8f9ec1f249dd552065aa37c983bed4d4d869bb0
+    # Use datetime only if no gitlog is used in the analysis.
+    #start_datetime: 2013-05-01 00:00:00
+    #end_datetime: 2013-11-01 00:00:00
+    size_days: 90
+#  enumeration:
+     # If using gitlog, specify the commits
+#    commit:
+#      - 9eae9e96f15e1f216162810cef4271a439a74223
+#      - f1d2d568776b3708dd6a3077376e2331f9268b04
+#      - c33a2ce74c84f0d435bfa2dd8953d132ebf7a77a
+     # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/analysisC.yml
+++ b/conf/analysisC.yml
@@ -1,0 +1,149 @@
+# -*- yaml -*-
+# Analysis specific configuration (camel)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+    - java_code_examples
+  remove_filepaths_on_commit_size_greather_than:
+    - 30
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: java
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  dv8:
+    # The project folder path to store various intermediate
+    # files for DV8 Analysis
+    # The folder name will be used in the file names.
+    folder_path: ../../analysis/camel/dv8/camel_1_6
+    # the architectural flaws thresholds that should be used
+    architectural_flaws:
+      cliqueDepends:
+        - call
+        - use
+      crossingCochange: 2
+      crossingFanIn: 4
+      crossingFanOut: 4
+      mvCochange: 2
+      uiCochange: 2
+      uihDepends:
+        - call
+        - use
+      uihInheritance:
+        - extend
+        - implement
+        - public
+        - private
+        - virtual
+      uiHistoryImpact: 10
+      uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+#      c:
+#        - f # function definition
+#      cpp:
+#        - c # classes
+#        - f # function definition
+      java:
+        - c # classes
+#        - m # methods
+#      python:
+#        - c # classes
+#        - f # functions
+#      r:
+#        - f # functions
+  # srcML allow to parse src code as text (e.g. identifiers)
+  srcml:
+    # The file path to where you wish to store the srcml output of the project
+    srcml_path: ../../analysis/camel/srcml/srcml_camel.xml
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+  # pattern4:
+  #   # The file path to where you wish to store the classes of the pattern4 analysis
+  #   class_folder_path: ../../rawdata/junit5/pattern4/classes/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  #   # The file path to where you wish to store the output of the pattern4 analysis
+  #  output_filepath: ../../analysis/junit5/pattern4/
+  #   compile_note: >
+  #     1. Switch Java version to Java 17:
+  #        https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+  #     2. Disable VPN to pull modules from Gradle Plugin Portal.
+  #     3. Use sudo ./gradlew build
+  #     4. After building, locate the engine class files and specify as the class_folder_path:
+  #        in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  topics:
+    topic_1:
+      - Parser
+      - Lexer
+    topic_2:
+      - Python
+      - Ruby
+  # You can specify the intervals in 2 ways: window, or enumeration
+#  window:
+    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+#    start_commit: 9eae9e96f15e1f216162810cef4271a439a74223
+#    end_commit: f8f9ec1f249dd552065aa37c983bed4d4d869bb0
+    # Use datetime only if no gitlog is used in the analysis.
+    #start_datetime: 2013-05-01 00:00:00
+    #end_datetime: 2013-11-01 00:00:00
+#    size_days: 90
+#  enumeration:
+     # If using gitlog, specify the commits
+#    commit:
+#      - 9eae9e96f15e1f216162810cef4271a439a74223
+#      - f1d2d568776b3708dd6a3077376e2331f9268b04
+#      - c33a2ce74c84f0d435bfa2dd8953d132ebf7a77a
+     # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/analysisD.yml
+++ b/conf/analysisD.yml
@@ -1,0 +1,148 @@
+# -*- yaml -*-
+# Analysis specific configuration (chromium)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+  # remove_filepaths_on_commit_size_greather_than:
+    # - 30
+
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: java
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  # dv8:
+  #   # The project folder path to store various intermediate
+  #   # files for DV8 Analysis
+  #   # The folder name will be used in the file names.
+  #   folder_path: ../../analysis/junit/dv8/
+  #   # the architectural flaws thresholds that should be used
+  #   architectural_flaws:
+  #     cliqueDepends:
+  #       - call
+  #       - use
+  #     crossingCochange: 2
+  #     crossingFanIn: 4
+  #     crossingFanOut: 4
+  #     mvCochange: 2
+  #     uiCochange: 2
+  #     uihDepends:
+  #       - call
+  #       - use
+  #     uihInheritance:
+  #       - extend
+  #       - implement
+  #       - public
+  #       - private
+  #       - virtual
+  #     uiHistoryImpact: 10
+  #     uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+      c:
+        - f # function definition
+      cpp:
+        - c # classes
+        - f # function definition
+      java:
+        - c # classes
+        - m # methods
+      python:
+        - c # classes
+        - f # functions
+      r:
+        - f # functions
+  # # srcML allow to parse src code as text (e.g. identifiers)
+  # srcml:
+  #   # The file path to where you wish to store the srcml output of the project
+  #   srcml_path: ../../analysis/junit5/srcml/srcml_junit.xml
+  # pattern4:
+  #   # The file path to where you wish to store the classes of the pattern4 analysis
+  #   class_folder_path: ../../rawdata/junit5/pattern4/classes/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  #   # The file path to where you wish to store the output of the pattern4 analysis
+  #  output_filepath: ../../analysis/junit5/pattern4/
+  #   compile_note: >
+  #     1. Switch Java version to Java 17:
+  #        https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+  #     2. Disable VPN to pull modules from Gradle Plugin Portal.
+  #     3. Use sudo ./gradlew build
+  #     4. After building, locate the engine class files and specify as the class_folder_path:
+  #        in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  # topics:
+    # topic_1:
+      # - Parser
+      # - Lexer
+    # topic_2:
+      # - Python
+      # - Ruby
+  # You can specify the intervals in 2 ways: window, or enumeration
+  window:
+    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+    #start_commit: 224a729f44f554af311ca52cf01b105ded87499b
+    #end_commit: 74cd4d4835a02e01e310476c6776192ad0d97173
+    # Use datetime only if no gitlog is used in the analysis.
+    #start_datetime: 2013-05-01 00:00:00
+    #end_datetime: 2013-11-01 00:00:00
+    #size_days: 30
+#  enumeration:
+     # If using gitlog, specify the commits
+#    commit:
+#      - 9eae9e96f15e1f216162810cef4271a439a74223
+#      - f1d2d568776b3708dd6a3077376e2331f9268b04
+#      - c33a2ce74c84f0d435bfa2dd8953d132ebf7a77a
+     # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/analysisG.yml
+++ b/conf/analysisG.yml
@@ -1,0 +1,165 @@
+# -*- yaml -*-
+# Analysis specific configuration (junit5)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+    - java_code_examples
+  # remove_filepaths_on_commit_size_greather_than:
+    # - 30
+
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: java
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  dv8:
+    # The project folder path to store various intermediate
+    # files for DV8 Analysis
+    # The folder name will be used in the file names.
+    folder_path: ../../analysis/junit5/dv8/
+    # the architectural flaws thresholds that should be used
+    architectural_flaws:
+      cliqueDepends:
+        - call
+        - use
+      crossingCochange: 2
+      crossingFanIn: 4
+      crossingFanOut: 4
+      mvCochange: 2
+      uiCochange: 2
+      uihDepends:
+        - call
+        - use
+      uihInheritance:
+        - extend
+        - implement
+        - public
+        - private
+        - virtual
+      uiHistoryImpact: 10
+      uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+#      c:
+#        - f # function definition
+#      cpp:
+#        - c # classes
+#        - f # function definition
+      java:
+        - c # classes
+#        - m # methods
+#      python:
+#        - c # classes
+#        - f # functions
+#      r:
+#        - f # functions
+  # srcML allow to parse src code as text (e.g. identifiers)
+  srcml:
+    # The file path to where you wish to store the srcml output of the project
+    srcml_path: ../../analysis/junit5/srcml/srcml_junit.xml
+  pattern4:
+    # The file path to where you wish to store the classes of the pattern4 analysis
+    class_folder_path: ../../rawdata/junit5/git_repo/junit5/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+    # The file path to where you wish to store the output of the pattern4 analysis
+    output_filepath: ../../analysis/junit5/pattern4/
+    compile_note: >
+      1. Switch Java version to Java 17:
+         https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+      2. Disable VPN to pull modules from Gradle Plugin Portal.
+      3. Use sudo ./gradlew build
+      4. After building, locate the engine class files and specify as the class_folder_path:
+         in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  topics:
+    topic_1:
+      - model
+      - view
+      - controller
+    topic_2:
+      - visitor
+    topic_3:
+      - observer
+      - listener
+    topic_4:
+      - adapter
+    topic_5:
+      - decorator
+    topic_6:
+      - factory
+      - builder
+    topic_7:
+      - facade
+    topic_8:
+      - strategy
+    topic_9:
+      - command
+  # You can specify the intervals in 2 ways: window, or enumeration
+#  window:
+#    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+#    start_commit: 9eae9e96f15e1f216162810cef4271a439a74223
+#    end_commit: f8f9ec1f249dd552065aa37c983bed4d4d869bb0
+#    # Use datetime only if no gitlog is used in the analysis.
+#    start_datetime: 2013-05-01 00:00:00
+#    end_datetime: 2013-11-01 00:00:00
+#    size_days: 90
+#  enumeration:
+#    # If using gitlog, specify the commits
+#    commit:
+#      - 9eae9e96f15e1f216162810cef4271a439a74223
+#      - f1d2d568776b3708dd6a3077376e2331f9268b04
+#      - c33a2ce74c84f0d435bfa2dd8953d132ebf7a77a
+#    # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/analysisJ.yml
+++ b/conf/analysisJ.yml
@@ -1,0 +1,147 @@
+# -*- yaml -*-
+# Analysis specific configuration (tomcat)
+
+filter:
+  keep_filepaths_ending_with:
+    - cpp
+    - c
+    - h
+    - java
+    - js
+    - py
+    - cc
+  remove_filepaths_containing:
+    - test
+  # remove_filepaths_on_commit_size_greather_than:
+    # - 30
+
+
+# Third Party Tools Configuration #
+#
+# See Kaiaulu's README.md for details on how to setup these tools.
+tool:
+  # Depends allow to parse file-file static dependencies.
+  depends:
+    # accepts one language at a time: cpp, java, ruby, python, pom
+    # You can obtain this information on OpenHub or the project GiHub page right pane.
+    code_language: java
+    # Specify which types of Dependencies to keep - see the Depends tool README.md for details.
+    keep_dependencies_type:
+      - Cast
+      - Call
+      - Import
+      - Return
+      - Set
+      - Use
+      - Implement
+      - ImplLink
+      - Extend
+      - Create
+      - Throw
+      - Parameter
+      - Contain
+  # dv8:
+  #   # The project folder path to store various intermediate
+  #   # files for DV8 Analysis
+  #   # The folder name will be used in the file names.
+  #   folder_path: ../../analysis/junit/dv8/
+  #   # the architectural flaws thresholds that should be used
+  #   architectural_flaws:
+  #     cliqueDepends:
+  #       - call
+  #       - use
+  #     crossingCochange: 2
+  #     crossingFanIn: 4
+  #     crossingFanOut: 4
+  #     mvCochange: 2
+  #     uiCochange: 2
+  #     uihDepends:
+  #       - call
+  #       - use
+  #     uihInheritance:
+  #       - extend
+  #       - implement
+  #       - public
+  #       - private
+  #       - virtual
+  #     uiHistoryImpact: 10
+  #     uiStructImpact: 0.01
+  # Uctags allows finer file-file dependency parsing (e.g. functions, classes, structs)
+  uctags:
+    # See https://github.com/sailuh/kaiaulu/wiki/Universal-Ctags for details
+    # What types of file-file dependencies should be considered? If all
+    # dependencies are specified, Kaiaulu will use all of them if available.
+    keep_lines_type:
+      c:
+        - f # function definition
+      cpp:
+        - c # classes
+        - f # function definition
+      java:
+        - c # classes
+        - m # methods
+      python:
+        - c # classes
+        - f # functions
+      r:
+        - f # functions
+  # # srcML allow to parse src code as text (e.g. identifiers)
+  # srcml:
+  #   # The file path to where you wish to store the srcml output of the project
+  #   srcml_path: ../../analysis/junit5/srcml/srcml_junit.xml
+  # pattern4:
+  #   # The file path to where you wish to store the classes of the pattern4 analysis
+  #   class_folder_path: ../../rawdata/junit5/pattern4/classes/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  #   # The file path to where you wish to store the output of the pattern4 analysis
+  #  output_filepath: ../../analysis/junit5/pattern4/
+  #   compile_note: >
+  #     1. Switch Java version to Java 17:
+  #        https://stackoverflow.com/questions/69875335/macos-how-to-install-java-17
+  #     2. Disable VPN to pull modules from Gradle Plugin Portal.
+  #     3. Use sudo ./gradlew build
+  #     4. After building, locate the engine class files and specify as the class_folder_path:
+  #        in this case they are in: /path/to/junit5/analysis/junit-platform-engine/build/classes/java/main/org/junit/platform/engine/
+  # understand:
+  #   # Accepts one language at a time: ada, assembly, c/c++, c#, fortran, java, jovial, delphi/pascal, python, vhdl, basic, javascript
+  #   code_language: java
+  #   # Specify which types of Dependencies to keep
+  #   keep_dependencies_type:
+  #     - Import
+  #     - Call
+  #     - Create
+  #     - Use
+  #     - Type GenericArgument
+  #   # Where the files to analyze should be stored
+  #   project_path: ../../rawdata/kaiaulu/git_repo/understand/
+  #   # Where the output for the understands analysis is stored
+  #   output_path: ../../analysis/kaiaulu/understand/
+
+# Analysis Configuration #
+analysis:
+  # A list of topic and keywords (see src_text_showcase.Rmd).
+  # topics:
+    # topic_1:
+      # - Parser
+      # - Lexer
+    # topic_2:
+      # - Python
+      # - Ruby
+  # You can specify the intervals in 2 ways: window, or enumeration
+  window:
+    # If using gitlog, use start_commit and end_commit. Timestamp is inferred from gitlog
+    #start_commit: 9eae9e96f15e1f216162810cef4271a439a74223
+    #end_commit: f8f9ec1f249dd552065aa37c983bed4d4d869bb0
+    # Use datetime only if no gitlog is used in the analysis.
+    #start_datetime: 2013-05-01 00:00:00
+    #end_datetime: 2013-11-01 00:00:00
+    #size_days: 90
+  enumeration:
+     # If using gitlog, specify the commits
+    commit:
+      - f3c9fdd40bdbc3dc22b512596954e2bc6d424d5a
+      - 0446c5c97741344556c519a566db926d660e4b8a
+     # Use datetime only if no gitlog is used in the analysis. Timestamp is inferred from gitlog
+#    datetime:
+#      - 2013-05-01 00:00:00
+#      - 2013-08-01 00:00:00
+#      - 2013-11-01 00:00:00

--- a/conf/calculator_project.yml
+++ b/conf/calculator_project.yml
@@ -1,0 +1,120 @@
+# -*- yaml -*-
+# Project data configuration (calculator)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  #website: https://apr.apache.org/
+  #openhub: https://www.openhub.net/p/apache_portable_runtime
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  log: ../../rawdata/Calculator/git_repo/Calculator/.git
+  # From where the git log was downloaded?
+  log_url: https://github.com/HouariZegai/Calculator
+  # List of branches used for analysis
+  branch:
+    - master
+
+# mailing_list:
+#   mod_mbox:
+#     project_key_1:
+#       mailing_list: http://mail-archives.apache.org/mod_mbox/kaiaulu-dev
+#       save_folder_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: http://mail-archives.apache.org/mod_mbox/kaiaulu-user
+#       save_folder_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/kaiaulu.mbox
+#   pipermail:
+#     project_key_1:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-dev/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-users/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/kaiaulu.mbox
+
+issue_tracker:
+#  jira:
+#    project_key_1:
+#      # Obtained from the project's JIRA URL
+#      domain: https://sailuh.atlassian.net
+#      project_key: SAILUH
+#      # Download using `download_jira_data.Rmd`
+#      issues: ../../rawdata/kaiaulu/jira/sailuh/issues/
+#      issue_comments: ../../rawdata/kaiaulu/jira/sailuh/issue_comments/
+  github:
+    project_key_1:
+      # Obtained from the project's GitHub URL
+      owner: HouariZegai
+      repo: Calculator
+      # Download using `download_github_comments.Rmd`
+      issue_or_pr_comment: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue_or_pr_comment/
+      issue: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue/
+      issue_search: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue_search/
+      issue_event: ../../rawdata/Calculator/github/HouariZegai_Calculator/issue_event/
+      pull_request: ../../rawdata/Calculator/github/HouariZegai_Calculator/pull_request/
+      pr_comments: ../../rawdata/Calculator/github/HouariZegai_Calculator/pr_comments/
+      commit: ../../rawdata/Calculator/github/HouariZegai_Calculator/commit/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_or_pr_comment/
+#       issue: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue/
+#       issue_search: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_search/
+#       issue_event: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_event/
+#       pull_request: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/pull_request/
+#       commit: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/commit/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issues/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issue_comments/
+
+#vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  #nvd_feed: rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+commit_message_id_regex:
+  issue_id: \#[0-9]+
+  #cve_id: ?

--- a/conf/camel_project.yml
+++ b/conf/camel_project.yml
@@ -1,0 +1,122 @@
+# -*- yaml -*-
+# Project data configuration (camel)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  website: https://github.com/apache/camel
+  #openhub: https://www.openhub.net/p/apache_portable_runtime
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  log: ../../rawdata/camel/git_repo/.git
+  # From where the git log was downloaded?
+  log_url: https://github.com/apache/camel
+  # List of branches used for analysis
+  branch:
+    - camel-1.6.0
+    - camel-1.0.0
+    - camel-2.11.4
+    - camel-3.21.0
+
+mailing_list:
+  mod_mbox:
+    project_key_1:
+      mailing_list: http://mail-archives.apache.org/mod_mbox/camel-dev
+      save_folder_path: ../../rawdata/camel/mod_mbox/save_mbox_mail/
+      # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#      mbox_file_path: ../../rawdata/camel/mod_mbox/save_mbox_mail/camel.mbox
+    project_key_2:
+      mailing_list: http://mail-archives.apache.org/mod_mbox/camel-users
+      save_folder_path: ../../rawdata/camel/mod_mbox/save_mbox_mail_2/
+      # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/camel.mbox
+#   pipermail:
+#     project_key_1:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-dev/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-users/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/kaiaulu.mbox
+
+issue_tracker:
+  jira:
+    project_key_1:
+      # Obtained from the project's JIRA URL
+      domain: https://issues.apache.org/jira
+      project_key: CAMEL
+      # Download using `download_jira_data.Rmd`
+      issues: ../../rawdata/camel/jira/issues/
+      issue_comments: ../../rawdata/camel/jira/issue_comments/
+#   github:
+#     project_key_1:
+#       # Obtained from the project's GitHub URL
+#       owner: sailuh
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/sailuh_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/sailuh_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/sailuh_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/sailuh_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/sailuh_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/sailuh_kaiaulu/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_or_pr_comment/
+#       issue: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue/
+#       issue_search: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_search/
+#       issue_event: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/issue_event/
+#       pull_request: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/pull_request/
+#       commit: ../../rawdata/kaiaulu/github/ssunoo2_kaiaulu/commit/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issues/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/kaiaulu/issue_comments/
+
+#vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  #nvd_feed: rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+commit_message_id_regex:
+  issue_id: CAMEL-[0-9]+
+  #cve_id: ?

--- a/conf/chromium_project.yml
+++ b/conf/chromium_project.yml
@@ -1,0 +1,122 @@
+# -*- yaml -*-
+# Project data configuration (chromium)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  website: https://www.chromium.org/
+  #openhub: https://www.openhub.net/p/chrome/
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  # log: ../../rawdata/chromium/git_repo/chromium/.git
+  log: ../rawdata/chromium/git_repo/chromium/.git
+  # From where the git log was downloaded?
+  log_url: https://chromium.googlesource.com/chromium/src
+  # List of branches used for analysis
+  branch:
+    - master
+
+# mailing_list:
+#   mod_mbox:
+#     project_key_1:
+#       mailing_list: http://mail-archives.apache.org/mod_mbox/kaiaulu-dev
+#       save_folder_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: http://mail-archives.apache.org/mod_mbox/kaiaulu-user
+#       save_folder_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/kaiaulu.mbox
+#   pipermail:
+#     project_key_1:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-dev/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-users/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/kaiaulu.mbox
+
+# issue_tracker:
+#   jira:
+#     project_key_1:
+#       # Obtained from the project's JIRA URL
+#       domain: https://sailuh.atlassian.net
+#       project_key: SAILUH
+#       # Download using `download_jira_data.Rmd`
+#       issues: ../../rawdata/kaiaulu/jira/issues/sailuh/
+#       issue_comments: ../../rawdata/kaiaulu/jira/issue_comments/sailuh/
+#   github:
+#     project_key_1:
+#       # Obtained from the project's GitHub URL
+#       owner: sailuh
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/sailuh_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/sailuh_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/sailuh_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/sailuh_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/sailuh_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/sailuh_kaiaulu/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+
+vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  nvd_feed: ../../rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+commit_message_id_regex:
+  # bug=119250,bug=117627,bug=118317,bug=139744,bug=127449,bug=122654,bug=100879,bug=112961,
+  # bug=113496,bug=127522,bug=132890
+  #issue_id: ?
+  cve_id: (?i)CVE-[0-9]+-[0-9]+

--- a/conf/experiment.yml
+++ b/conf/experiment.yml
@@ -1,0 +1,25 @@
+# -*- yaml -*-
+# This experiment .yml file has all projects that are currently being used in Kaiaulu.
+# It shows which project configurations are paired with which analysis configurations.
+
+projects:
+ apr_project.yml:
+    - analysisA.yml
+ calculator_project.yml:
+    - analysisB.yml
+ camel_project.yml:
+     - analysisC.yml
+ chromium_project.yml:
+     - analysisD.yml
+ geronimo_project.yml:
+     - analysisE.yml
+ helix_project.yml:
+     - analysisF.yml
+ junit5_project.yml:
+     - analysisG.yml
+ kaiaulu_project.yml:
+     - analysisH.yml
+ openssl_project.yml:
+     - analysisI.yml
+ tomcat_project.yml:
+     - analysisJ.yml

--- a/conf/experiment_java.yml
+++ b/conf/experiment_java.yml
@@ -1,0 +1,21 @@
+# -*- yaml -*-
+# This experiment .yml file contains only projects that use/support Java.
+# It shows which project configurations are paired with which analysis configurations.
+
+projects:
+ calculator_project.yml:
+    - analysisB.yml
+ camel_project.yml:
+     - analysisC.yml
+ chromium_project.yml:
+     - analysisD.yml
+ geronimo_project.yml:
+     - analysisE.yml
+ helix_project.yml:
+     - analysisF.yml
+ junit5_project.yml:
+     - analysisG.yml
+ kaiaulu_project.yml:
+     - analysisH.yml
+ tomcat_project.yml:
+     - analysisJ.yml

--- a/conf/junit5_project.yml
+++ b/conf/junit5_project.yml
@@ -1,0 +1,120 @@
+# -*- yaml -*-
+# Project data configuration (junit5)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  website: https://github.com/junit-team/junit5/
+  #openhub: https://www.openhub.net/p/apache_portable_runtime
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  # log: ../../rawdata/git_repo/junit5/.git
+  log: ../../rawdata/junit5/git_repo/junit5/.git
+  # From where the git log was downloaded?
+  log_url: https://github.com/junit-team/junit5/
+  # List of branches used for analysis
+  branch:
+    - main
+
+# mailing_list:
+#   mod_mbox:
+#     project_key_1:
+#       mailing_list: http://mail-archives.apache.org/mod_mbox/kaiaulu-dev
+#       save_folder_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: http://mail-archives.apache.org/mod_mbox/kaiaulu-user
+#       save_folder_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/kaiaulu.mbox
+#   pipermail:
+#     project_key_1:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-dev/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-users/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/kaiaulu.mbox
+
+# issue_tracker:
+#   jira:
+#     project_key_1:
+#       # Obtained from the project's JIRA URL
+#       domain: https://sailuh.atlassian.net
+#       project_key: SAILUH
+#       # Download using `download_jira_data.Rmd`
+#       issues: ../../rawdata/kaiaulu/jira/issues/sailuh/
+#       issue_comments: ../../rawdata/kaiaulu/jira/issue_comments/sailuh/
+#   github:
+#     project_key_1:
+#       # Obtained from the project's GitHub URL
+#       owner: sailuh
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/sailuh_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/sailuh_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/sailuh_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/sailuh_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/sailuh_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/sailuh_kaiaulu/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+
+#vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  # nvd_feed: rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+# commit_message_id_regex:
+#  issue_id: \#[0-9]+
+#  cve_id: ?

--- a/conf/tomcat_project.yml
+++ b/conf/tomcat_project.yml
@@ -1,0 +1,119 @@
+# -*- yaml -*-
+# Project data configuration (tomcat)
+
+# https://github.com/sailuh/kaiaulu
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Project Configuration File #
+#
+# To perform analysis on open source projects, you need to manually
+# collect some information from the project's website. As there is
+# no standardized website format, this file serves to distill
+# important data source information so it can be reused by others
+# and understood by Kaiaulu.
+#
+# Please check https://github.com/sailuh/kaiaulu/tree/master/conf to
+# see if a project configuration file already exists. Otherwise, we
+# would appreciate if you share your curated file with us by sending a
+# Pull Request: https://github.com/sailuh/kaiaulu/pulls
+#
+# Note, you do NOT need to specify this entire file to conduct analysis.
+# Each R Notebook uses a different portion of this file. To know what
+# information is used, see the project configuration file section at
+# the start of each R Notebook.
+#
+# Please comment unused parameters instead of deleting them for clarity.
+# If you have questions, please open a discussion:
+# https://github.com/sailuh/kaiaulu/discussions
+
+project:
+  website: https://tomcat.apache.org
+  openhub: https://www.openhub.net/p/tomcat
+
+version_control:
+  # Where is the git log located locally?
+  # This is the path to the .git of the project repository you are analyzing.
+  # The .git is hidden, so you can see it using `ls -a`
+  log: ../../rawdata/tomcat/git_repo/.git
+  # From where the git log was downloaded?
+  log_url: https://github.com/apache/tomcat
+  # List of branches used for analysis
+  branch:
+    - master
+
+mailing_list:
+  mod_mbox:
+    project_key_1:
+      mailing_list: http://mail-archives.apache.org/mod_mbox/tomcat-dev
+      save_folder_path: ../../rawdata/tomcat/mod_mbox/save_mbox_mail/
+      # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#      mbox_file_path: ../../rawdata/tomcat/mod_mbox/save_mbox_mail/tomcat.mbox
+    project_key_2:
+      mailing_list: http://mail-archives.apache.org/mod_mbox/tomcat-users
+      save_folder_path: ../../rawdata/tomcat/mod_mbox/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/mod_mbox/save_mbox_mail_2/tomcat.mbox
+#   pipermail:
+#     project_key_1:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-dev/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail/kaiaulu.mbox
+#     project_key_2:
+#       mailing_list: https://mta.openssl.org/pipermail/kaiaulu-users/
+#       save_folder_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/
+#       # mbox_file_path is for use only with parse_mbox() function. It is the file to parse
+#       mbox_file_path: ../../rawdata/kaiaulu/pipermail/save_mbox_mail_2/kaiaulu.mbox
+
+# issue_tracker:
+#   jira:
+#     project_key_1:
+#       # Obtained from the project's JIRA URL
+#       domain: https://sailuh.atlassian.net
+#       project_key: SAILUH
+#       # Download using `download_jira_data.Rmd`
+#       issues: ../../rawdata/kaiaulu/jira/issues/sailuh/
+#       issue_comments: ../../rawdata/kaiaulu/jira/issue_comments/sailuh/
+#   github:
+#     project_key_1:
+#       # Obtained from the project's GitHub URL
+#       owner: sailuh
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/sailuh_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/sailuh_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/sailuh_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/sailuh_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/sailuh_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/sailuh_kaiaulu/
+#     project_key_2:
+#       # Obtained from the project's GitHub URL
+#       owner: ssunoo2
+#       repo: kaiaulu
+#       # Download using `download_github_comments.Rmd`
+#       issue_or_pr_comment: ../../rawdata/kaiaulu/github/issue_or_pr_comment/ssunoo2_kaiaulu/
+#       issue: ../../rawdata/kaiaulu/github/issue/ssunoo2_kaiaulu/
+#       issue_search: ../../rawdata/kaiaulu/github/issue_search/ssunoo2_kaiaulu/
+#       issue_event: ../../rawdata/kaiaulu/github/issue_event/ssunoo2_kaiaulu/
+#       pull_request: ../../rawdata/kaiaulu/github/pull_request/ssunoo2_kaiaulu/
+#       commit: ../../rawdata/kaiaulu/github/commit/ssunoo2_kaiaulu/
+#   bugzilla:
+#     project_key_1:
+#       project_key: kaiaulu
+#       issues: ../../rawdata/kaiaulu/bugzilla/issues/kaiaulu/
+#       issue_comments: ../../rawdata/kaiaulu/bugzilla/issue_comments/kaiaulu/
+
+#vulnerabilities:
+  # Folder path with nvd cve feeds (e.g. nvdcve-1.1-2018.json)
+  # Download at: https://nvd.nist.gov/vuln/data-feeds
+  #nvd_feed: rawdata/nvdfeed
+
+# Commit message CVE or Issue Regular Expression (regex)
+# See project's commit message for examples to create the regex
+commit_message_id_regex:
+  #issue_id: ?
+  cve_id: (?i)CVE-[0-9]+-[0-9]+

--- a/vignettes/bug_count.Rmd
+++ b/vignettes/bug_count.Rmd
@@ -37,19 +37,33 @@ As usual, the first step is to load the project configuration file.
 
 ```{r}
 tool <- parse_config("../tools.yml")
-conf <- parse_config("../conf/geronimo.yml")
+# conf <- parse_config("../conf/geronimo.yml")
+
+# Reads 2 configs
+project <- parse_config("../conf/geronimo_immutable.yml")
+analysis <- parse_config("../conf/analysis1.yml")
 perceval_path <- get_tool_project("perceval", tool)
-git_repo_path <- get_git_repo_path(conf)
+
+# Used for project.yml
+git_repo_path <- get_git_repo_path(project)
+issue_id_regex <- get_issue_id_regex(project)
+jira_issues_path <- get_jira_issues_path(project, "project_key_1")
+
+# Used for analysis.yml
+file_extensions <- get_file_extensions(analysis)
+substring_filepath <- get_substring_filepath(analysis)
+
+# git_repo_path <- get_git_repo_path(conf)
 
 # Issue ID Regex on Commit Messages
-issue_id_regex <- get_issue_id_regex(conf)
+# issue_id_regex <- get_issue_id_regex(conf)
 # Path to Jira Issues (obtained using `download_jira_data Notebook`)
 # Specify project_key_index in get_jira_issues_path() (e.g. "project_key_1")
-jira_issues_path <- get_jira_issues_path(conf, "project_key_1")
+# jira_issues_path <- get_jira_issues_path(conf, "project_key_1")
 
 # Filters
-file_extensions <- get_file_extensions(conf)
-substring_filepath <- get_substring_filepath(conf)
+# file_extensions <- get_file_extensions(conf)
+# substring_filepath <- get_substring_filepath(conf)
 ```
 
 To establish bug count, we must map each file to its associated issue. In general (but not always), an open source project will adopt a commit message convention to label issue ids. For example, Kaiaulu uses `i #<issue number>`. JIRA dictates issue ids in the format PROJECT-<issue-number>. We can use this assumption to find the issues that the git log commits are trying to fix. You can create your own regular expression by manually inspecting some of the commit messages (for example, compare the regular expression from the geronimo project used here against [its commit message](https://github.com/apache/geronimo/commits/trunk)).


### PR DESCRIPTION
Based on Issue #397.
Refactored all the configuration files that are currently being used in Kaiaulu notebooks. These are the remainder .yml files that weren't covered in issues #359, #366, #376. Also included the bug count notebook changes in #387 as this issue only had the notebook change and no other file changes.

All the configuration project .yml file + associated analysis.yml files:

- calculator_project.yml + analysisB.yml
- camel_project.yml + analysisC.yml
- chromium_project.yml + analysisD.yml
- junit5_project.yml + analysisG.yml
- tomcat_project.yml + analysisJ.yml

Also includes an experiment.yml and experiment_java.yml file that shows which project configurations are paired with which analysis configurations.

- experiment.yml show all projects that are currently being used in Kaiaulu.
- experiment_java.yml only projects that use/support Java.

Notebook Changes:
The notebooks now read 2 configs (project + analysis .yml files).
- bug_count.Rmd